### PR TITLE
Added support for model names different from file names

### DIFF
--- a/ModelUploader/README.md
+++ b/ModelUploader/README.md
@@ -16,7 +16,8 @@ Modeluploader simply traverses the contents of a directory tree via a breadth-fi
 
 In order for this tool to operate, the user must:
 
-1. Update the [serviceConfig.json](serviceConfig.json) file to include connection details for their ADT Instance. The `tenantId` field is filled with the GUID of the Microsoft 365 tenant's Active Directory. The value of `clientId` is the GUID given by the App Registration for ADT. The value of `instanceUrl` is the DNS name of the ADT instance, prepended by `https://`.
+1. Update the [serviceConfig.json](serviceConfig.json) file to include connection details for their ADT Instance. The `tenantId` field is filled with the GUID of the Microsoft 365 tenant's Active Directory. The value of `clientId` is the GUID given by the App Registration for ADT. The value of `instanceUrl` is the DNS name of the ADT instance, prepended by `https://`. if the `tenantId` field is empty, the [default Azure credentials](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme) will be used.
+
 2. Ensure that `serviceConfig.json` is copied to the output directory from which the ModelUploader is executed. This is set under [ModelUploader.csproj](ModelUploader.csproj) and should be activated by default.
 
 ## Example usage


### PR DESCRIPTION
Creating dependent models, used in extensions and properties of model interfaces, didn't work when the model name was different from the file name. Fixed this and now even different versions of the same model interface are supported.

Tested the changes with the ontology from opendigitaltwins-building.

Integrated changes from original PR #2 and closed it. Changes from this PR:
Fixed a small bug with zero console window width and height and added DefaultAzureCredentials authentication.