### PR TITLE
Add new versions of UploadModels and DeleteModels

### DIFF
--- a/ADTTools/ADTTools.sln
+++ b/ADTTools/ADTTools.sln
@@ -9,6 +9,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ADTToolsLibrary", "ADTTools
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteModels", "DeleteModels\DeleteModels.csproj", "{B4F2A68B-11DC-48F2-A489-9F75D46EDD55}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{639464E5-56C0-4C27-BDEC-B23007B04118}"
+	ProjectSection(SolutionItems) = preProject
+		Readme.md = Readme.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/ADTTools/ADTTools.sln
+++ b/ADTTools/ADTTools.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31229.75
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UploadModels", "UploadModels\UploadModels.csproj", "{147FC65A-1653-4E66-982E-CC524523AE29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ADTToolsLibrary", "ADTToolsLibrary\ADTToolsLibrary.csproj", "{D51B20C1-F002-457F-9E20-D37146181723}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{147FC65A-1653-4E66-982E-CC524523AE29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{147FC65A-1653-4E66-982E-CC524523AE29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{147FC65A-1653-4E66-982E-CC524523AE29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{147FC65A-1653-4E66-982E-CC524523AE29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D51B20C1-F002-457F-9E20-D37146181723}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D51B20C1-F002-457F-9E20-D37146181723}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D51B20C1-F002-457F-9E20-D37146181723}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D51B20C1-F002-457F-9E20-D37146181723}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {ABEE0472-7C22-45EE-9899-C93C741A12C4}
+	EndGlobalSection
+EndGlobal

--- a/ADTTools/ADTTools.sln
+++ b/ADTTools/ADTTools.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UploadModels", "UploadModel
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ADTToolsLibrary", "ADTToolsLibrary\ADTToolsLibrary.csproj", "{D51B20C1-F002-457F-9E20-D37146181723}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteModels", "DeleteModels\DeleteModels.csproj", "{B4F2A68B-11DC-48F2-A489-9F75D46EDD55}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{D51B20C1-F002-457F-9E20-D37146181723}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D51B20C1-F002-457F-9E20-D37146181723}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D51B20C1-F002-457F-9E20-D37146181723}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4F2A68B-11DC-48F2-A489-9F75D46EDD55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4F2A68B-11DC-48F2-A489-9F75D46EDD55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4F2A68B-11DC-48F2-A489-9F75D46EDD55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4F2A68B-11DC-48F2-A489-9F75D46EDD55}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ADTTools/ADTToolsLibrary/ADTToolsLibrary.csproj
+++ b/ADTTools/ADTToolsLibrary/ADTToolsLibrary.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/ADTTools/ADTToolsLibrary/Log.cs
+++ b/ADTTools/ADTToolsLibrary/Log.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace ADTToolsLibrary
+{
+    public static class Log
+    {
+        static public void Write(string s, ConsoleColor col = ConsoleColor.White)
+        {
+            Console.ForegroundColor = col;
+            Console.WriteLine(s);
+            Console.ResetColor();
+        }
+
+        static public void Error(string s)
+        {
+            Write(s, ConsoleColor.DarkRed);
+        }
+
+        static public void Warning(string s)
+        {
+            Write(s, ConsoleColor.DarkYellow);
+        }
+
+        static public void Ok(string s)
+        {
+            Write(s, ConsoleColor.DarkGreen);
+        }
+    }
+}

--- a/ADTTools/DeleteModels/DeleteModels.csproj
+++ b/ADTTools/DeleteModels/DeleteModels.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.DigitalTwins.Core" Version="1.2.2" />
+    <PackageReference Include="Azure.Identity" Version="1.4.0" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ADTToolsLibrary\ADTToolsLibrary.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ADTTools/DeleteModels/Options.cs
+++ b/ADTTools/DeleteModels/Options.cs
@@ -1,0 +1,16 @@
+﻿using CommandLine;
+
+namespace DeleteModels
+{
+    internal class Options
+    {
+        [Option('t', "tenantId", Required = true, HelpText = "The application's tenant id for connecting to Azure Digital Twins.")]
+        public string TenantId { get; set; }
+
+        [Option('c', "clientId", Required = true, HelpText = "The application's client id for connecting to Azure Digital Twins.")]
+        public string ClientId { get; set; }
+
+        [Option('h', "hostName", Required = true, HelpText = "The host name of your Azure Digital Twins instance.")]
+        public string HostName { get; set; }
+    }
+}

--- a/ADTTools/DeleteModels/Program.cs
+++ b/ADTTools/DeleteModels/Program.cs
@@ -1,0 +1,66 @@
+﻿using ADTToolsLibrary;
+using Azure;
+using Azure.DigitalTwins.Core;
+using Azure.Identity;
+using CommandLine;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace DeleteModels
+{
+    class Program
+    {
+        private readonly Options options;
+
+        static void Main(string[] args)
+        {
+            Parser.Default.ParseArguments<Options>(args).WithParsed(options => new Program(options).Run());
+        }
+
+        private Program(Options options)
+        {
+            this.options = options;
+        }
+
+        private void Run()
+        {
+            try
+            {
+                var credential = new InteractiveBrowserCredential(options.TenantId, options.ClientId);
+                var client = new DigitalTwinsClient(new UriBuilder("https", options.HostName).Uri, credential);
+                DeleteAllModels(client, 1);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Deleting models failed.");
+                Log.Error(ex.Message);
+            }
+        }
+
+        private void DeleteAllModels(DigitalTwinsClient client, int iteration)
+        {
+            foreach (DigitalTwinsModelData modelData in client.GetModels())
+            {
+                try
+                {
+                    client.DeleteModel(modelData.Id);
+                    Log.Ok($"Deleted model '{modelData.Id}' (Iteration {iteration})");
+                }
+                catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Conflict)
+                {
+                    // This model is a dependent and will be deleted in the next iteration.
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"Failed to delete model '{modelData.Id}': {ex.Message}");
+                }
+            }
+
+            if (client.GetModels().Any())
+            {
+                DeleteAllModels(client, iteration + 1);
+            }
+        }
+    }
+}

--- a/ADTTools/Readme.md
+++ b/ADTTools/Readme.md
@@ -1,0 +1,49 @@
+# Azure Digital Twins tools
+
+This set of tools is designed to make it easy to manage DTDL ontologies with the Azure Digital Twins service.
+
+## UploadModels
+
+UploadModels is used to upload an ontology (set of models) into an Azure Digital Twins service instance. The tool accepts a list of models (including wildcard and glob support), validates the models using the digital twins parser, orders the models so that "root" models are uploaded first, and then uploads models in batches for fast uploading.
+
+### Usage
+
+`UploadModels [options] <fileList>`
+
+### Options
+
+Upload
+- `-t` or `--tenantId`: The id (GUID) of your tenant or directory in Azure.
+- `-c` or `--clientId`: The id (GUID) of an Azure Active Directory app registration. See [Create an app registration to use with Azure Digital Twins](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-create-app-registration) for more information.
+- `-h` or `--hostName`: The host name of your Azure Digital Twins service instance (no https prefix needed).
+
+Test
+- `-w` or `--whatIf`: When set, without the upload options, displays an ordered list of the models that would be uploaded.
+
+### File list
+
+- fileList: A list of model file names that supports wildcards and globs.
+
+### Example usage
+
+- Upload one model: `UploadModels -t 42a9ff5e-dd3a-4a89-8d92-2a7eaadbfcaa -c 198783fb-4301-4983-a12f-4eefb696282d -h briancr-ms.api.wcus.digitaltwins.azure.net .\MyModel.json`
+- Upload an ontology: `UploadModels -t 42a9ff5e-dd3a-4a89-8d92-2a7eaadbfcaa -c 198783fb-4301-4983-a12f-4eefb696282d -h briancr-ms.api.wcus.digitaltwins.azure.net \Ontology\**\*.json`
+- Display an ordered list of models that would be uploaded: `UploadModels -w \Ontology\**\*.json`
+
+## DeleteModels
+
+DeleteModels is used to delete all the models in an Azure Digital Twins service instance. The tool deletes the models recursively so that "leaf" models are deleted first and "root" models are deleted last.
+
+### Usage
+
+`DeleteModels [options]`
+
+### Options
+
+- `-t` or `--tenantId`: The id (GUID) of your tenant or directory in Azure.
+- `-c` or `--clientId`: The id (GUID) of an Azure Active Directory app registration. See [Create an app registration to use with Azure Digital Twins](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-create-app-registration) for more information.
+- `-h` or `--hostName`: The host name of your Azure Digital Twins service instance (no https prefix needed).
+
+### Example usage
+
+- Delete all models: `DeleteModels -t 42a9ff5e-dd3a-4a89-8d92-2a7eaadbfcaa -c 198783fb-4301-4983-a12f-4eefb696282d -h briancr-ms.api.wcus.digitaltwins.azure.net`

--- a/ADTTools/UploadModels/DTInterfaceInfoEqualityComparer.cs
+++ b/ADTTools/UploadModels/DTInterfaceInfoEqualityComparer.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Azure.DigitalTwins.Parser;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace UploadModels
+{
+    internal class DTInterfaceInfoEqualityComparer : IEqualityComparer<DTInterfaceInfo>
+    {
+        public bool Equals([AllowNull] DTInterfaceInfo x, [AllowNull] DTInterfaceInfo y)
+        {
+            if (ReferenceEquals(x, null) && ReferenceEquals(y, null))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+            {
+                return false;
+            }
+            else
+            {
+                return x.Id.Equals(y.Id);
+            }
+        }
+
+        public int GetHashCode([DisallowNull] DTInterfaceInfo obj)
+        {
+            return obj.Id.GetHashCode();
+        }
+    }
+}

--- a/ADTTools/UploadModels/Options.cs
+++ b/ADTTools/UploadModels/Options.cs
@@ -1,0 +1,29 @@
+﻿using CommandLine;
+using System.Collections.Generic;
+
+namespace UploadModels
+{
+    class Options
+    {
+        [Option('t', "tenantId", SetName = "upload", Required = true, HelpText = "The application's tenant id for connecting to Azure Digital Twins.")]
+        public string TenantId { get; set; }
+
+        [Option('c', "clientId", SetName = "upload", Required = true, HelpText = "The application's client id for connecting to Azure Digital Twins.")]
+        public string ClientId { get; set; }
+
+        [Option('h', "hostName", SetName = "upload", Required = true, HelpText = "The host name of your Azure Digital Twins instance.")]
+        public string HostName { get; set; }
+
+        [Option('b', "batchSize", SetName = "upload", Default = 100, HelpText = "The maximum number of models uploaded in each batch (default 100).")]
+        public int BatchSize { get; set; }
+
+        [Option('d', "deleteFirst", SetName = "upload", Required = false, Default = false, HelpText = "Delete the models before uploading (default false).")]
+        public bool DeleteFirst { get; set; }
+
+        [Option('w', "whatIf", SetName = "whatif", Required = true, Default = false, HelpText = "Display the order of the models that would be uploaded, but do not upload.")]
+        public bool WhatIf { get; set; }
+
+        [Value(0, Required = true, HelpText = "Model file names to upload (supports globs).")]
+        public IEnumerable<string> FileSpecs { get; set; }
+    }
+}

--- a/ADTTools/UploadModels/Options.cs
+++ b/ADTTools/UploadModels/Options.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace UploadModels
 {
-    class Options
+    internal class Options
     {
         [Option('t', "tenantId", SetName = "upload", Required = true, HelpText = "The application's tenant id for connecting to Azure Digital Twins.")]
         public string TenantId { get; set; }
@@ -16,9 +16,6 @@ namespace UploadModels
 
         [Option('b', "batchSize", SetName = "upload", Default = 100, HelpText = "The maximum number of models uploaded in each batch (default 100).")]
         public int BatchSize { get; set; }
-
-        [Option('d', "deleteFirst", SetName = "upload", Required = false, Default = false, HelpText = "Delete the models before uploading (default false).")]
-        public bool DeleteFirst { get; set; }
 
         [Option('w', "whatIf", SetName = "whatif", Required = true, Default = false, HelpText = "Display the order of the models that would be uploaded, but do not upload.")]
         public bool WhatIf { get; set; }

--- a/ADTTools/UploadModels/OrderedHashSet.cs
+++ b/ADTTools/UploadModels/OrderedHashSet.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace UploadModels
+{
+    internal class OrderedHashSet<T> : KeyedCollection<T, T>
+    {
+        public OrderedHashSet()
+        {
+        }
+
+        public OrderedHashSet(IEqualityComparer<T> comparer)
+            : base(comparer)
+        {
+        }
+
+        protected override T GetKeyForItem(T item)
+        {
+            return item;
+        }
+    }
+}

--- a/ADTTools/UploadModels/Program.cs
+++ b/ADTTools/UploadModels/Program.cs
@@ -16,7 +16,7 @@ namespace UploadModels
 {
     class Program
     {
-        private Options options;
+        private readonly Options options;
 
         static async Task Main(string[] args)
         {

--- a/ADTTools/UploadModels/Program.cs
+++ b/ADTTools/UploadModels/Program.cs
@@ -1,0 +1,245 @@
+﻿using ADTToolsLibrary;
+using Azure;
+using Azure.DigitalTwins.Core;
+using Azure.Identity;
+using CommandLine;
+using Ganss.IO;
+using Microsoft.Azure.DigitalTwins.Parser;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace UploadModels
+{
+    class Program
+    {
+        private Options options;
+
+        static async Task Main(string[] args)
+        {
+            await Parser.Default.ParseArguments<Options>(args).WithParsedAsync(options => new Program(options).Run());
+        }
+
+        private Program(Options options)
+        {
+            this.options = options;
+        }
+
+        private async Task Run()
+        {
+            // Expand globs and wildcards for all file specs.
+            IEnumerable<string> fileNames = GetFileNames(options.FileSpecs);
+
+            // Load all the model text.
+            var modelTexts = new Dictionary<string, string>();
+            foreach (string fileName in fileNames)
+            {
+                modelTexts.Add(fileName, File.ReadAllText(fileName));
+                Log.Write($"Loaded: {fileName}");
+            }
+
+            Log.Write(string.Empty);
+
+            // Check that all model text is valid JSON (for better error reporting).
+            if (!ParseModelJson(modelTexts))
+            {
+                return;
+            }
+
+            // Parse models.
+            IReadOnlyDictionary<Dtmi, DTEntityInfo> entities = await ParseModelsAsync(modelTexts);
+            if (entities == null)
+            {
+                return;
+            }
+
+            // Get interfaces.
+            IEnumerable<DTInterfaceInfo> interfaces = from entity in entities.Values
+                                                      where entity.EntityKind == DTEntityKind.Interface
+                                                      select (DTInterfaceInfo)entity;
+            Log.Ok($"Parsed {interfaces.Count()} models successfully.");
+            Log.Write(string.Empty);
+
+            // Order interfaces for upload.
+            IEnumerable<DTInterfaceInfo> orderedInterfaces = OrderInterfaces(interfaces);
+
+            if (options.WhatIf)
+            {
+                DisplayOrderedInterfaces(orderedInterfaces);
+            }
+            else
+            {
+                await UploadOrderedInterfaces(orderedInterfaces);
+            }
+        }
+
+        private async Task UploadOrderedInterfaces(IEnumerable<DTInterfaceInfo> orderedInterfaces)
+        {
+            Log.Write("Uploaded interfaces:");
+            try
+            {
+                var credential = new InteractiveBrowserCredential(options.TenantId, options.ClientId);
+                var client = new DigitalTwinsClient(new UriBuilder("https", options.HostName).Uri, credential);
+
+                for (int i = 0; i < (orderedInterfaces.Count() / options.BatchSize) + 1; i++)
+                {
+                    IEnumerable<DTInterfaceInfo> batch = orderedInterfaces.Skip(i * options.BatchSize).Take(options.BatchSize);
+                    Response<DigitalTwinsModelData[]> response = await client.CreateModelsAsync(batch.Select(i => i.GetJsonLdText()));
+                    foreach (DTInterfaceInfo @interface in batch)
+                    {
+                        Log.Ok(@interface.Id.AbsoluteUri);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Upload failed.");
+                Log.Error(ex.Message);
+            }
+        }
+
+        private static void DisplayOrderedInterfaces(IEnumerable<DTInterfaceInfo> orderedInterfaces)
+        {
+            Log.Write("Ordered interfaces:");
+            foreach (DTInterfaceInfo orderedInterface in orderedInterfaces)
+            {
+                Log.Write(orderedInterface.Id.AbsoluteUri);
+            }
+
+        }
+
+        private static bool ParseModelJson(Dictionary<string, string> modelTexts)
+        {
+            var jsonErrors = new Dictionary<string, System.Text.Json.JsonException>();
+            foreach (string fileName in modelTexts.Keys)
+            {
+                try
+                {
+                    JsonDocument jsonDoc = JsonDocument.Parse(modelTexts[fileName]);
+                }
+                catch (System.Text.Json.JsonException ex)
+                {
+                    jsonErrors.Add(fileName, ex);
+                }
+            }
+
+            if (jsonErrors.Count > 0)
+            {
+                Log.Error("Errors parsing models.");
+                foreach (string fileName in jsonErrors.Keys)
+                {
+                    Log.Error($"{fileName}: {jsonErrors[fileName].Message}");
+                }
+            }
+
+            return jsonErrors.Count == 0;
+        }
+
+        private static async Task<IReadOnlyDictionary<Dtmi, DTEntityInfo>> ParseModelsAsync(Dictionary<string, string> modelTexts)
+        {
+            IReadOnlyDictionary<Dtmi, DTEntityInfo> entities = null;
+            try
+            {
+                var parser = new ModelParser();
+                entities = await parser.ParseAsync(modelTexts.Values);
+            }
+            catch (ParsingException ex)
+            {
+                Log.Error("Errors parsing models.");
+                foreach (ParsingError error in ex.Errors)
+                {
+                    Log.Error(error.Message);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Errors parsing models.");
+                Log.Error(ex.Message);
+            }
+
+            return entities;
+        }
+
+        private static IEnumerable<DTInterfaceInfo> OrderInterfaces(IEnumerable<DTInterfaceInfo> interfaces)
+        {
+            // This function sorts interfaces from interfaces with no dependencies to interfaces with dependencies.
+            // Using a depth-first search and post-order processing, we get an ordering from no dependencies to most dependencies.
+
+            // Build the set of all referenced interfaces.
+            HashSet<DTInterfaceInfo> referencedInterfaces = new HashSet<DTInterfaceInfo>(new DTInterfaceInfoEqualityComparer());
+            foreach (DTInterfaceInfo @interface in interfaces)
+            {
+                foreach (DTInterfaceInfo referencedInterface in @interface.Extends)
+                {
+                    referencedInterfaces.Add(referencedInterface);
+                }
+
+                IEnumerable<DTInterfaceInfo> componentSchemas = from content in @interface.Contents.Values
+                                                                where content.EntityKind == DTEntityKind.Component
+                                                                select ((DTComponentInfo)content).Schema;
+                foreach (DTInterfaceInfo referencedInterface in componentSchemas)
+                {
+                    referencedInterfaces.Add(referencedInterface);
+                }
+            }
+
+            // The roots of the trees are all the interfaces that are not referenced.
+            IEnumerable<DTInterfaceInfo> rootInterfaces = interfaces.Except(referencedInterfaces, new DTInterfaceInfoEqualityComparer());
+
+            // For each root, perform depth-first, post-order processing to produce a sorted tree.
+            OrderedHashSet<DTInterfaceInfo> orderedInterfaces = new OrderedHashSet<DTInterfaceInfo>(new DTInterfaceInfoEqualityComparer());
+            foreach (DTInterfaceInfo rootInterface in rootInterfaces)
+            {
+                OrderedHashSet<DTInterfaceInfo> rootInterfaceOrderedInterfaces = new OrderedHashSet<DTInterfaceInfo>(new DTInterfaceInfoEqualityComparer());
+                OrderInterface(rootInterfaceOrderedInterfaces, rootInterface);
+                foreach (DTInterfaceInfo rootInterfaceOrderedInterface in rootInterfaceOrderedInterfaces)
+                {
+                    if (!orderedInterfaces.Contains(rootInterfaceOrderedInterface))
+                    {
+                        orderedInterfaces.Add(rootInterfaceOrderedInterface);
+                    }
+                }
+            }
+
+            return orderedInterfaces;
+        }
+
+        private static void OrderInterface(OrderedHashSet<DTInterfaceInfo> orderedInterfaces, DTInterfaceInfo @interface)
+        {
+            // Order each extended interface.
+            foreach (DTInterfaceInfo extendedInterface in @interface.Extends)
+            {
+                OrderInterface(orderedInterfaces, extendedInterface);
+            }
+
+            // Order each component schema interface.
+            IEnumerable<DTInterfaceInfo> componentSchemas = from content in @interface.Contents.Values
+                                                            where content.EntityKind == DTEntityKind.Component
+                                                            select ((DTComponentInfo)content).Schema;
+            foreach (DTInterfaceInfo componentSchemaInterface in componentSchemas)
+            {
+                OrderInterface(orderedInterfaces, componentSchemaInterface);
+            }
+
+            // Add this interface to the list of ordered interfaces.
+            if (!orderedInterfaces.Contains(@interface))
+            {
+                orderedInterfaces.Add(@interface);
+            }
+        }
+
+        private static IEnumerable<string> GetFileNames(IEnumerable<string> fileSpecs)
+        {
+            IEnumerable<string> fileNames = Enumerable.Empty<string>();
+            foreach (string fileSpec in fileSpecs)
+            {
+                fileNames = fileNames.Concat(Glob.Expand(fileSpec).Select(fsi => fsi.FullName));
+            }
+
+            return fileNames;
+        }
+    }
+}

--- a/ADTTools/UploadModels/UploadModels.csproj
+++ b/ADTTools/UploadModels/UploadModels.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.DigitalTwins.Core" Version="1.2.2" />
+    <PackageReference Include="Azure.Identity" Version="1.4.0" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Glob.cs" Version="5.1.766" />
+    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ADTToolsLibrary\ADTToolsLibrary.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds new versions of UploadModels and DeleteModels tools that work with the Azure Digital Twins services.

UploadModels is similar to ModelUploader but supports more file specifications (including wildcards and globs) as well as model upload ordering based on the digital twins parser.

DeleteModels is much like the -d option in the ModelUploader tool, but separated into a separate tool.