### PR TITLE
Announcing Deprecation of ModelUploader (to be replaced by ADTTools\UploadModels and DeleteModels

### DIFF
--- a/ModelUploader/README.md
+++ b/ModelUploader/README.md
@@ -1,5 +1,5 @@
 # NOTICE! THIS TOOL WILL BE DEPRECATED ON AUGUST 1st 2021
-# Please refer to (ADTTools)[https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools] for a replacement tool
+# Please refer to [ADTTools](https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools) for a replacement set of tools
 
 
 # The ADT Model Uploader

--- a/ModelUploader/README.md
+++ b/ModelUploader/README.md
@@ -1,3 +1,7 @@
+# NOTICE! THIS TOOL WILL BE DEPRECATED ON AUGUST 1st 2021
+# Please refer to (ADTTools)[https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools] for a replacement tool
+
+
 # The ADT Model Uploader
 
 **Author:** [Karl Hammar](https://karlhammar.com), [Akshay Johar](https://github.com/Azure/opendigitaltwins-building-tools/commits?author=akshayj-MSFT)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ DTDL is the language by which developers can define the language of the entities
 
 This is a set of open-source ontology tools which one can use to operate on any ontologies, including the [Real Estate Core Ontology](https://github.com/Azure/opendigitaltwins-building)
 
-## Upload the models to Azure Digital Twins
-You can upload this ontology into your own instance of ADT by using [Model Uploader](ModelUploader). Follow the instructions on ModelUploader to upload all of these models into your own instance. Here is [an article](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-model) on how to manage models, update, retrieve, update, decommission and delete models.
+## Uploading models to Azure Digital Twins
+You can upload this ontology into your own instance of ADT by using [https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools/UploadModels](UploadModels). Follow the [https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools#azure-digital-twins-tools](instructions) on Upload to upload all of these models into your own instance. Here is [an article](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-model) on how to manage models, update, retrieve, update, decommission and delete models.
+
+## Deleting models in bulk
+You can also delete models that are previously uploaded to an instance of ADT. For this you can use the [https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools#deletemodels](DeleteModels) tool. Instructions of how this can be run are found [](here)
 
 ## Visualizing the models
 Once you have uploaded these models into your Azure Digital Twins instance, you can view the ontology using [ADT Model Visualizer](AdtModelVisualizer). This tool is a draft version (read-only visualizer, no edits) and we invite you to contribute to it to make it better.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ DTDL is the language by which developers can define the language of the entities
 This is a set of open-source ontology tools which one can use to operate on any ontologies, including the [Real Estate Core Ontology](https://github.com/Azure/opendigitaltwins-building)
 
 ## Uploading models to Azure Digital Twins
-You can upload this ontology into your own instance of ADT by using [https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools/UploadModels](UploadModels). Follow the [https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools#azure-digital-twins-tools](instructions) on Upload to upload all of these models into your own instance. Here is [an article](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-model) on how to manage models, update, retrieve, update, decommission and delete models.
+You can upload this ontology into your own instance of ADT by using [UploadModels](https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools/UploadModels). Follow the [instructions](https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools#azure-digital-twins-tools) on Upload to upload all of these models into your own instance. Here is [an article](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-model) on how to manage models, update, retrieve, update, decommission and delete models.
 
 ## Deleting models in bulk
-You can also delete models that are previously uploaded to an instance of ADT. For this you can use the [https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools#deletemodels](DeleteModels) tool. Instructions of how this can be run are found [](here)
+You can also delete models that are previously uploaded to an instance of ADT. For this you can use the [DeleteModels](https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools/DeleteModels) tool. Instructions of how this can be run are found [here](https://github.com/Azure/opendigitaltwins-tools/tree/master/ADTTools#deletemodels)
 
 ## Visualizing the models
 Once you have uploaded these models into your Azure Digital Twins instance, you can view the ontology using [ADT Model Visualizer](AdtModelVisualizer). This tool is a draft version (read-only visualizer, no edits) and we invite you to contribute to it to make it better.


### PR DESCRIPTION
Since briancr-ms brought his tools UploadModels and DeleteModels, this ModelUploader is now obsolete, and needs to be retired. This change is to announce the deprecation of ModelUploader , and point the Tools section to the right links for the new tools