### PR TITLE
Adding support for regex in the mappings files

### DIFF
--- a/OntologyMapper/src/OntologyMapper.csproj
+++ b/OntologyMapper/src/OntologyMapper.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Description>This is the Microsoft Smart Places Facilities Ontology Mapper library.</Description>
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -9,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.4.1</AssemblyVersion>
-		<PackageVersion>0.4.1-preview</PackageVersion>
+		<AssemblyVersion>0.5.0</AssemblyVersion>
+		<PackageVersion>0.5.0-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<Copyright>Copyright (c) Microsoft Corporation.  All rights reserved.</Copyright>
 		<AssemblyName>Microsoft.SmartPlaces.Facilities.OntologyMapper</AssemblyName>

--- a/OntologyMapper/src/OntologyMappingManager.cs
+++ b/OntologyMapper/src/OntologyMappingManager.cs
@@ -5,6 +5,7 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
 {
     using Microsoft.Azure.DigitalTwins.Parser;
     using Microsoft.Azure.DigitalTwins.Parser.Models;
+    using System.Text.RegularExpressions;
 
     public class OntologyMappingManager : IOntologyMappingManager
     {
@@ -39,9 +40,9 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
             return false;
         }
 
-        public bool TryGetPropertyProjection(string outputDtmiFilter, string outputPropertyName, out PropertyProjection? propertyProjection)
+        public bool TryGetPropertyProjection(string outputDtmi, string outputPropertyName, out PropertyProjection? propertyProjection)
         {
-            propertyProjection = OntologyMapping.PropertyProjections.FirstOrDefault(e => e.OutputDtmiFilter == outputDtmiFilter && e.OutputPropertyName == outputPropertyName);
+            propertyProjection = OntologyMapping.PropertyProjections.FirstOrDefault(e => (e.OutputDtmiFilter == "*" || Regex.Match(outputDtmi, e.OutputDtmiFilter, RegexOptions.IgnoreCase).Success) && e.OutputPropertyName == outputPropertyName);
 
             if (propertyProjection != null)
             {
@@ -51,9 +52,9 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
             return false;
         }
 
-        public bool TryGetFillProperty(string outputDtmiFilter, string outputPropertyName, out FillProperty? fillProperty)
+        public bool TryGetFillProperty(string outputDtmi, string outputPropertyName, out FillProperty? fillProperty)
         {
-            fillProperty = OntologyMapping.FillProperties.FirstOrDefault(e => e.OutputDtmiFilter == outputDtmiFilter && e.OutputPropertyName == outputPropertyName);
+            fillProperty = OntologyMapping.FillProperties.FirstOrDefault(e => (e.OutputDtmiFilter == "*" || Regex.Match(outputDtmi, e.OutputDtmiFilter, RegexOptions.IgnoreCase).Success) && e.OutputPropertyName == outputPropertyName);
 
             if (fillProperty != null)
             {

--- a/OntologyMapper/src/README.md
+++ b/OntologyMapper/src/README.md
@@ -113,13 +113,25 @@ A collection of mappings from one or more property names to another property nam
       "OutputPropertyName": "output-property-name",
       "InputPropertyNames": [ "input-property-name1", "input-property-name2" ],
       "IsOutputPropertyCollection": true
+    },
+    {
+      "OutputDtmiFilter": "\w*Space\w*",
+      "OutputPropertyName": "output-property-name",
+      "InputPropertyNames": [ "input-property-name2" ],
+      "IsOutputPropertyCollection": true
     }
+
   ],
   "FillProperties": [
     {
       "OutputDtmiFilter": "*",
       "OutputPropertyName": "output-property-name",
       "InputPropertyNames": [ "input-property-name1, input-property-name2" ]
+    },
+    {
+      "OutputDtmiFilter": "\w*Space\w*",
+      "OutputPropertyName": "output-property-name",
+      "InputPropertyNames": [ "input-property-name2, input-property-name1" ]
     }
   ]
 }
@@ -190,7 +202,7 @@ In some cases, the contents of one input property may need to be copied to multi
 
 | Name | Description |
 | --- | --- |
-| outputDtmiFilter | A regex which describes which output dtmi's this rule applies to |
+| outputDtmi | The output dtmi to which this search will be applied |
 | outputPropertyName | The name of the output property |
 | fillProperty | A fillProperty if it exists |
 
@@ -208,7 +220,7 @@ In some cases, a property of the input model needs to be put into a different fi
 
 | Name | Description |
 | --- | --- |
-| outputDtmiFilter | A regex which describes which output dtmi's this rule applies to |
+| outputDtmi | The output dtmi to which this search will be applied |
 | outputPropertyName | The name of the output property |
 | propertyProjection | The property projection for the output property |
 

--- a/OntologyMapper/test/OntologyMappingManagerTests.cs
+++ b/OntologyMapper/test/OntologyMappingManagerTests.cs
@@ -115,17 +115,53 @@ namespace OntologyMapper.Test
 
             var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
 
-            var outputDtmiFilter = "*";
+            var outputDtmi = "dtmi:org:w3id:rec:Space;1";
             var outputPropertyName = "externalIds";
             var inputPropertyName = "deviceKey";
 
-            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmiFilter, outputPropertyName, out var propertyProjection);
+            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmi, outputPropertyName, out var propertyProjection);
 
             Assert.True(result);
             Assert.NotNull(propertyProjection);
-            Assert.Equal(outputDtmiFilter, propertyProjection.OutputDtmiFilter);
             Assert.Equal(outputPropertyName, propertyProjection.OutputPropertyName);
             Assert.Equal(inputPropertyName, propertyProjection.InputPropertyNames[0]);
+        }
+
+        [Fact]
+        public void TryGetPropertyProjection_ReturnsTrue_WhenRegexMatchFound()
+        {
+            var mockOntologyLoader = new Mock<IOntologyMappingLoader>();
+            mockOntologyLoader.Setup(m => m.LoadOntologyMapping()).Returns(GetOntologyMapping);
+
+            var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
+
+            var outputDtmi = "dtmi:org:w3id:rec:Motor;1";
+            var outputPropertyName = "externalMotors";
+            var inputPropertyName = "deviceMotor";
+
+            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmi, outputPropertyName, out var propertyProjection);
+
+            Assert.True(result);
+            Assert.NotNull(propertyProjection);
+            Assert.Equal(outputPropertyName, propertyProjection.OutputPropertyName);
+            Assert.Equal(inputPropertyName, propertyProjection.InputPropertyNames[0]);
+        }
+
+        [Fact]
+        public void TryGetPropertyProjection_ReturnsTrue_WhenRegexMatchNotFound()
+        {
+            var mockOntologyLoader = new Mock<IOntologyMappingLoader>();
+            mockOntologyLoader.Setup(m => m.LoadOntologyMapping()).Returns(GetOntologyMapping);
+
+            var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
+
+            var outputDtmi = "dtmi:org:w3id:rec:Engine;1";
+            var outputPropertyName = "externalMotors";
+
+            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmi, outputPropertyName, out var propertyProjection);
+
+            Assert.False(result);
+            Assert.Null(propertyProjection);
         }
 
         [Fact]
@@ -136,16 +172,15 @@ namespace OntologyMapper.Test
 
             var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
 
-            var outputDtmiFilter = "*";
+            var outputDtmi = "dtmi:org:w3id:rec:Space;1";
             var outputPropertyName = "externalIds";
             var inputPropertyName1 = "deviceKey";
             var inputPropertyName2 = "deviceId";
 
-            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmiFilter, outputPropertyName, out var propertyProjections);
+            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmi, outputPropertyName, out var propertyProjections);
 
             Assert.True(result);
             Assert.NotNull(propertyProjections);
-            Assert.Equal(outputDtmiFilter, propertyProjections.OutputDtmiFilter);
             Assert.Equal(outputPropertyName, propertyProjections.OutputPropertyName);
             Assert.Equal(inputPropertyName1, propertyProjections.InputPropertyNames[0]);
             Assert.Equal(inputPropertyName2, propertyProjections.InputPropertyNames[1]);
@@ -159,10 +194,10 @@ namespace OntologyMapper.Test
 
             var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
 
-            var outputDtmiFilter = "*";
+            var outputDtmi = "dtmi:org:w3id:rec:Space;1";
             var outputPropertyName = "external";
 
-            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmiFilter, outputPropertyName, out var propertyProjection);
+            var result = ontologyMappingManager.TryGetPropertyProjection(outputDtmi, outputPropertyName, out var propertyProjection);
 
             Assert.False(result);
             Assert.Null(propertyProjection);
@@ -176,16 +211,53 @@ namespace OntologyMapper.Test
 
             var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
 
-            var outputDtmiFilter = "*";
+            var outputDtmi = "dtmi:org:w3id:rec:Space;1";
             var outputPropertyName = "name";
 
-            var result = ontologyMappingManager.TryGetFillProperty(outputDtmiFilter, outputPropertyName, out var propertyFill);
+            var result = ontologyMappingManager.TryGetFillProperty(outputDtmi, outputPropertyName, out var propertyFill);
 
             Assert.True(result);
             Assert.NotNull(propertyFill);
             Assert.Equal(2, propertyFill.InputPropertyNames.Count());
             Assert.Equal("name", propertyFill.InputPropertyNames.ToList()[0]);
             Assert.Equal("description", propertyFill.InputPropertyNames.ToList()[1]);
+        }
+
+        [Fact]
+        public void TryGetFillProperty_ReturnsTrue_When_FoundByRegex()
+        {
+            var mockOntologyLoader = new Mock<IOntologyMappingLoader>();
+            mockOntologyLoader.Setup(m => m.LoadOntologyMapping()).Returns(GetOntologyMapping);
+
+            var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
+
+            var outputDtmi = "dtmi:org:w3id:rec:Motor;1";
+            var outputPropertyName = "fan";
+
+            var result = ontologyMappingManager.TryGetFillProperty(outputDtmi, outputPropertyName, out var propertyFill);
+
+            Assert.True(result);
+            Assert.NotNull(propertyFill);
+            Assert.Equal(2, propertyFill.InputPropertyNames.Count());
+            Assert.Equal("name", propertyFill.InputPropertyNames.ToList()[0]);
+            Assert.Equal("description", propertyFill.InputPropertyNames.ToList()[1]);
+        }
+
+        [Fact]
+        public void TryGetFillProperty_ReturnsTrue_When_NotFoundByRegex()
+        {
+            var mockOntologyLoader = new Mock<IOntologyMappingLoader>();
+            mockOntologyLoader.Setup(m => m.LoadOntologyMapping()).Returns(GetOntologyMapping);
+
+            var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
+
+            var outputDtmi = "dtmi:org:w3id:rec:Motor;1";
+            var outputPropertyName = "switch";
+
+            var result = ontologyMappingManager.TryGetFillProperty(outputDtmi, outputPropertyName, out var propertyFill);
+
+            Assert.False(result);
+            Assert.Null(propertyFill);
         }
 
         [Fact]
@@ -196,10 +268,10 @@ namespace OntologyMapper.Test
 
             var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
 
-            var outputDtmiFilter = "*";
+            var outputDtmi = "dtmi:org:w3id:rec:Space;1";
             var outputPropertyName = "channel";
 
-            var result = ontologyMappingManager.TryGetFillProperty(outputDtmiFilter, outputPropertyName, out var propertyFill);
+            var result = ontologyMappingManager.TryGetFillProperty(outputDtmi, outputPropertyName, out var propertyFill);
 
             Assert.False(result);
             Assert.Null(propertyFill);
@@ -245,8 +317,10 @@ namespace OntologyMapper.Test
             ontologyMapping.Header.OutputOntologies.Add(new Ontology { DtdlVersion = "v3", Name = "org2", Version = "1.2" });
 
             ontologyMapping.PropertyProjections.Add(new PropertyProjection { OutputDtmiFilter = "*", InputPropertyNames = new List<string> { "deviceKey" }, OutputPropertyName = "externalIds", IsOutputPropertyCollection = true });
+            ontologyMapping.PropertyProjections.Add(new PropertyProjection { OutputDtmiFilter = @"\w*Motor\w*", InputPropertyNames = new List<string> { "deviceMotor" }, OutputPropertyName = "externalMotors", IsOutputPropertyCollection = true });
 
             ontologyMapping.FillProperties.Add(new FillProperty { OutputDtmiFilter = "*", OutputPropertyName = "name", InputPropertyNames = new string[] { "name", "description" } });
+            ontologyMapping.FillProperties.Add(new FillProperty { OutputDtmiFilter = @"\w*Motor\w*", OutputPropertyName = "fan", InputPropertyNames = new string[] { "name", "description" } });
 
             ontologyMapping.InterfaceRemaps.Add(new DtmiRemap { InputDtmi = "dtmi:twin:main:CleaningRoom;1", OutputDtmi = "dtmi:org:w3id:rec:CleanRoom;1" });
             ontologyMapping.InterfaceRemaps.Add(new DtmiRemap { InputDtmi = "dtmi:twin:main:RandomRoom;1", OutputDtmi = "dtmi:org:org1:schema:test:Office;1", IsIgnored = true });


### PR DESCRIPTION
Adding support for regex in the mappings files so that matches can be made only on certain types of dtmi's instead of always.

This allows for different mappings for fill properties and property projections depending on the dtmi passed in to the query