### PR TITLE
Adding Namespace remap

### DIFF
--- a/OntologyMapper/src/OntologyMapper.csproj
+++ b/OntologyMapper/src/OntologyMapper.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.5.1</AssemblyVersion>
-		<PackageVersion>0.5.1-preview</PackageVersion>
+		<AssemblyVersion>0.6.0</AssemblyVersion>
+		<PackageVersion>0.6.0-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<Copyright>Copyright (c) Microsoft Corporation.  All rights reserved.</Copyright>
 		<AssemblyName>Microsoft.SmartPlaces.Facilities.OntologyMapper</AssemblyName>

--- a/OntologyMapper/src/OntologyMapping.cs
+++ b/OntologyMapper/src/OntologyMapping.cs
@@ -16,6 +16,11 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
         public MappingHeader Header { get; set; } = new MappingHeader();
 
         /// <summary>
+        /// Mapping one namespace to another
+        /// </summary>
+        public List<NamespaceRemap> NamespaceRemaps { get; set; } = new List<NamespaceRemap>();
+
+        /// <summary>
         /// Mappings describing the translation from an input DTMI to an output DTMI. Note that only mappings where the input DTMI does not exactly match the output DTMI should be defined here.
         /// If the two DTMIs match exactly, they do not need to be added here
         /// </summary>
@@ -116,7 +121,7 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
     }
 
     /// <summary>
-    /// Maps an input input from the source ontology to an output interface in the target ontology
+    /// Maps an input interface from the source ontology to an output interface in the target ontology
     /// </summary>
     public class DtmiRemap
     {
@@ -152,6 +157,22 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
         /// The output relationship type as a string
         /// </summary>
         public string OutputRelationship { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Maps an input namespace from the source ontology to an output namespace in the target ontology
+    /// </summary>
+    public class NamespaceRemap
+    {
+        /// <summary>
+        /// The input namespace as a regex string
+        /// </summary>
+        public string InputNamespace { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The output namespace as a regex string
+        /// </summary>
+        public string OutputNamespace { get; set; } = string.Empty;
     }
 
     public class Ontology

--- a/OntologyMapper/src/OntologyMappingManager.cs
+++ b/OntologyMapper/src/OntologyMappingManager.cs
@@ -25,6 +25,19 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
                 return true;
             }
 
+            var namespaceRemap = OntologyMapping.NamespaceRemaps.FirstOrDefault(n => inputDtmi.ToString().Contains(n.InputNamespace));
+
+            if (namespaceRemap != null)
+            {
+                dtmiRemap = new DtmiRemap()
+                {
+                    InputDtmi = inputDtmi.ToString(),
+                    OutputDtmi = inputDtmi.ToString().Replace(namespaceRemap.InputNamespace, namespaceRemap.OutputNamespace)
+                };
+
+                return true;
+            }
+
             return false;
         }
 

--- a/OntologyMapper/src/README.md
+++ b/OntologyMapper/src/README.md
@@ -37,6 +37,17 @@ A collection of what ontologies make up the output source for the conversion
 | DtdlVersion | Which version of the DTDL language is currently in use for this provider |
 
 
+### NamespaceRemaps
+
+A collection of mappings from one namespace name to another namespace name. This is used after the explicit InterfaceRemaps to execute a simple search and replace of a string in
+an input model to convert it to an output model. That is, in those cases where the input model interface name is exactly the same as the output model interface name, but the namespace is different,
+then the input model''s namespace will be replaced by the NamespaceRemap's output namespace.
+
+| Field | Description |
+| --- | --- |
+| InputNamespace | The string to search for in the input dtmi |
+| OutputNamespace | The replacement string |
+
 ### InterfaceRemaps
 
 A collection of mappings from one interface name to another interface name. It is suggested that you only need to list mappings where the input DTMI is not the same as the output DTMI. Systems should assume that if a DTMI is not listed in the mappings, that the output DTMI will be the same as the input DTMI.
@@ -97,6 +108,12 @@ A collection of mappings from one or more property names to another property nam
       }
     ]
   },
+  "NamespaceRemaps": [
+    {
+      "InputDtmi": "dtmi:source-namespace:",
+      "OutputDtmi": "dtmi:target-namespace:"
+    },
+  ],
   "InterfaceRemaps": [
     {
       "InputDtmi": "dtmi:source-namespace:source-interface-name;1",
@@ -175,7 +192,7 @@ For a given DTMI from the source ontology, get the DTMI for the target ontology
 
 *Returns*
 
-`true` if a remap exists, otherwise `false`
+`true` if a remap exists, or if a namespaceremap exists for the namespace of the input dtmi, otherwise `false`
 
 **Method: TryGetRelationshipRemap**
 

--- a/OntologyMapper/test/OntologyMappingManagerTests.cs
+++ b/OntologyMapper/test/OntologyMappingManagerTests.cs
@@ -58,6 +58,23 @@ namespace OntologyMapper.Test
         }
 
         [Fact]
+        public void TryGetInterfaceRemapDtmi_ReturnsTrue_When_NamespaceRemapFound()
+        {
+            var mockOntologyLoader = new Mock<IOntologyMappingLoader>();
+            mockOntologyLoader.Setup(m => m.LoadOntologyMapping()).Returns(GetOntologyMapping);
+
+            var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
+
+            var inputDtmi = new Dtmi("dtmi:x:core:Sparkle;1");
+
+            var result = ontologyMappingManager.TryGetInterfaceRemapDtmi(inputDtmi, out var dtmiRemap);
+
+            Assert.True(result);
+            Assert.NotNull(dtmiRemap);
+            Assert.Equal("dtmi:com:y:Sparkle;1", dtmiRemap.OutputDtmi);
+        }
+
+        [Fact]
         public void TryGetInterfaceRemapDtmi_ReturnsFalse_When_NotFound()
         {
             var mockOntologyLoader = new Mock<IOntologyMappingLoader>();
@@ -355,6 +372,8 @@ namespace OntologyMapper.Test
             ontologyMapping.Header.InputOntologies.Add(new Ontology { DtdlVersion = "v2", Name = "twin", Version = "1.0" });
             ontologyMapping.Header.OutputOntologies.Add(new Ontology { DtdlVersion = "v2", Name = "org1", Version = "1.1" });
             ontologyMapping.Header.OutputOntologies.Add(new Ontology { DtdlVersion = "v3", Name = "org2", Version = "1.2" });
+
+            ontologyMapping.NamespaceRemaps.Add(new NamespaceRemap() { InputNamespace = "dtmi:x:core:", OutputNamespace = "dtmi:com:y:" });
 
             ontologyMapping.PropertyProjections.Add(new PropertyProjection { OutputDtmiFilter = ".*", InputPropertyNames = new List<string> { "deviceKey" }, OutputPropertyName = "externalIds", IsOutputPropertyCollection = true });
             ontologyMapping.PropertyProjections.Add(new PropertyProjection { OutputDtmiFilter = @"\w*Motor\w*", InputPropertyNames = new List<string> { "deviceMotor" }, OutputPropertyName = "externalMotors", IsOutputPropertyCollection = true, Priority = 0 });


### PR DESCRIPTION
Adding the ability to remap an entire namespace to a different namespace for interfaces in the case where the interface names are the same but the namespaces are different