### PR TITLE
Enable Rec Tests

### DIFF
--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/test/BrickRecMappingValidationTests.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/test/BrickRecMappingValidationTests.cs
@@ -98,35 +98,35 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Mapped.Test
             Assert.Empty(exceptions);
         }
 
-        //[Theory]
-        //[InlineData("Mappings.v1.BrickRec.mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json")]
-        //public void ValidateSourceDtmisAreValid(string resourcePath)
-        //{
-        //    var mockLogger = new Mock<ILogger>();
-        //    var resourceLoader = new MappedOntologyMappingLoader(mockLogger.Object, resourcePath);
-        //    var ontologyMappingManager = new OntologyMappingManager(resourceLoader);
-        //    var modelParser = new ModelParser();
-        //    var inputDtmi = LoadDtdl("mapped_dtdl.json");
-        //    var inputModels = modelParser.Parse(inputDtmi);
-        //    ontologyMappingManager.ValidateSourceOntologyMapping(inputModels, out var invalidSources);
+        [Theory]
+        [InlineData("Mappings.v1.BrickRec.mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json")]
+        public void ValidateSourceDtmisAreValid(string resourcePath)
+        {
+            var mockLogger = new Mock<ILogger>();
+            var resourceLoader = new MappedOntologyMappingLoader(mockLogger.Object, resourcePath);
+            var ontologyMappingManager = new OntologyMappingManager(resourceLoader);
+            var modelParser = new ModelParser();
+            var inputDtmi = LoadDtdl("mapped_dtdl.json");
+            var inputModels = modelParser.Parse(inputDtmi);
+            ontologyMappingManager.ValidateSourceOntologyMapping(inputModels, out var invalidSources);
 
-        //    Assert.Empty(invalidSources);
-        //}
+            Assert.Empty(invalidSources);
+        }
 
-        //[Theory]
-        //[InlineData("Mappings.v1.BrickRec.mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json")]
-        //public void ValidateTargetDtmisAreValid(string resourcePath)
-        //{
-        //    var mockLogger = new Mock<ILogger>();
-        //    var resourceLoader = new MappedOntologyMappingLoader(mockLogger.Object, resourcePath);
-        //    var ontologyMappingManager = new OntologyMappingManager(resourceLoader);
-        //    var modelParser = new ModelParser();
-        //    var inputDtmi = LoadDtdl("RealEstateCore_DTDLv2.json");
-        //    var inputModels = modelParser.Parse(inputDtmi);
-        //    ontologyMappingManager.ValidateTargetOntologyMapping(inputModels, out var invalidSources);
+        [Theory]
+        [InlineData("Mappings.v1.BrickRec.mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json")]
+        public void ValidateTargetDtmisAreValid(string resourcePath)
+        {
+            var mockLogger = new Mock<ILogger>();
+            var resourceLoader = new MappedOntologyMappingLoader(mockLogger.Object, resourcePath);
+            var ontologyMappingManager = new OntologyMappingManager(resourceLoader);
+            var modelParser = new ModelParser();
+            var inputDtmi = LoadDtdl("RealEstateCore_DTDLv2.json");
+            var inputModels = modelParser.Parse(inputDtmi);
+            ontologyMappingManager.ValidateTargetOntologyMapping(inputModels, out var invalidSources);
 
-        //    Assert.Empty(invalidSources);
-        //}
+            Assert.Empty(invalidSources);
+        }
 
         private IEnumerable<string> LoadDtdl(string dtdlFile)
         {

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/test/OntologyMapper.Mapped.Test.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/test/OntologyMapper.Mapped.Test.csproj
@@ -23,6 +23,7 @@
 		<PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
 		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.2.499" />
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+		<PackageReference Include="RealEstateCore.Ontology.DTDLv2" Version="4.0.0-preview" />
 		<PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
 		<PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />


### PR DESCRIPTION
Now that the Rec Nuget is available on Nuget, re-enable the tests for validating the mappings against the rec dtdl.