### PR TITLE
Fix CG alerts

### DIFF
--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from a Mapped DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.4.1</AssemblyVersion>
-		<PackageVersion>0.4.1-preview</PackageVersion>
+		<AssemblyVersion>0.4.2</AssemblyVersion>
+		<PackageVersion>0.4.2-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -32,6 +32,12 @@
 		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
 		<PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.2.1-preview" />
 		<PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+	</ItemGroup>
+
+	<!-- Added Explicitly for CVE-2021-24112 -->
+	<!-- Can be removed once StackExchange.Redis fixes the vulnerability -->
+	<ItemGroup>
+		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/IngestionManager.Mapped.Test.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/IngestionManager.Mapped.Test.csproj
@@ -12,12 +12,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
-		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.2.499" />
-		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.2.1-preview" />
 		<PackageReference Include="Moq" Version="4.18.2" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
@@ -33,7 +28,7 @@
 	</ItemGroup>
 
     <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
-	<!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
+	<!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>This is library injects data from one DTDL based graph, then converts and inserts the data into another DTDL base graph.</Description>
-		<AssemblyVersion>0.2.1</AssemblyVersion>
-		<PackageVersion>0.2.1-preview</PackageVersion>
+		<AssemblyVersion>0.2.2</AssemblyVersion>
+		<PackageVersion>0.2.2-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -20,11 +20,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.DigitalTwins.Core" Version="1.4.0" />
-		<PackageReference Include="Azure.Identity" Version="1.6.0" />
+		<PackageReference Include="Azure.Identity" Version="1.7.0" />
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
 		<PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
@@ -32,7 +32,13 @@
 		<PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper" Version="0.6.5-preview" />
 		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
 		<PackageReference Include="Polly" Version="7.2.3" />
-		<PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+		<PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+	</ItemGroup>
+
+	<!-- Added Explicitly for CVE-2021-24112 -->
+	<!-- Can be removed once StackExchange.Redis fixes the vulnerability -->
+	<ItemGroup>
+		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionManager.Test.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionManager.Test.csproj
@@ -37,7 +37,7 @@
 	</ItemGroup>
 
     <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
-	<!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
+	<!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>

--- a/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionManager.Test.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionManager.Test.csproj
@@ -19,17 +19,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
-		<PackageReference Include="Divergic.Logging.Xunit" Version="4.0.0" />
-		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-		<PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="coverlet.collector" Version="3.1.2" />
+		<PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 		<PackageReference Include="Moq" Version="4.18.2" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.4">
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -42,7 +39,7 @@
     <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
 	<!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
 	<ItemGroup>
-		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/test/OntologyMapper.Mapped.Test.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/test/OntologyMapper.Mapped.Test.csproj
@@ -22,13 +22,8 @@
 		</PackageReference>
 		<PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
 		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.2.499" />
-		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
 		<PackageReference Include="RealEstateCore.Ontology.DTDLv2" Version="4.0.0-preview" />
-		<PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-		<PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper" Version="0.6.5-preview" />
 		<PackageReference Include="Moq" Version="4.18.2" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
@@ -37,7 +37,7 @@
 	</ItemGroup>
 
     <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
-	<!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
+	<!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
@@ -21,8 +21,6 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 		<PackageReference Include="Moq" Version="4.18.2" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
@@ -41,6 +39,6 @@
     <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
 	<!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
 	<ItemGroup>
-		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
+++ b/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
@@ -49,6 +49,6 @@
     <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
 	<!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
 	<ItemGroup>
-		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
### What
Fix vulnerabilities in the code for GHSA-5crp-9r3c-p9vr and CVE-2021-24112

### Why
Vulnerabilities are bad

### How
Followed ComponentGovernance recommendations on how to resolve the vulnerabilities
git clean -xfd
Ran unit tests for all solutions