### PR TITLE
[SmartPlace.Facilities.Topology] Disable sampling in Topology Sample

### DIFF
--- a/SmartPlaces.Facilities/samples/Topology/src/Program.cs
+++ b/SmartPlaces.Facilities/samples/Topology/src/Program.cs
@@ -44,6 +44,7 @@ namespace Topology
                     services.AddApplicationInsightsTelemetryWorkerService(options =>
                     {
                         options.ConnectionString = hostContext.Configuration["AppInsightsConnectionString"];
+                        options.EnableAdaptiveSampling = false;
                     });
 
                     // Implements IInputGraphManager, IGraphIngestionProcessor, IOutputGraphManager, ITelemetryIngestionProcessor


### PR DESCRIPTION
### What
Disable Adaptive Sampling for AppInsights which is enabled by default.

### Why
When debugging processes for one-off exceptions AppInsights can sample them away if the majority of logs are successful as the lone exception is not representative of the volume of logs. Though by being sampled away makes it a roll of the dice to root cause issues.

### How
It is disabled in Telemetry and EdgeGateway which was successful. Confident in this small change.

Signed-off-by: Tyler Angell <47679282+Tyler-Angell@users.noreply.github.com>