### PR TITLE
[SmartPlaces.Facilities.Telemetry] Update cloud cache exception handling

### DIFF
--- a/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Exceptions/TelemetryValueException.cs
+++ b/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Exceptions/TelemetryValueException.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TargetTypeNotFoundException.cs" company="Microsoft">
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Telemetry.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// Custom exception for when there is an issue transforming telemetry value.
+    /// </summary>
+    public class TelemetryValueException : Exception
+    {
+        /// <summary>
+        /// Custom exception for when there is an issue transforming telemetry value.
+        /// </summary>
+        /// <param name="message">In your own words, describe what happened</param>
+        public TelemetryValueException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Custom exception for when there is an issue transforming telemetry value.
+        /// </summary>
+        /// <param name="message">In your own words, describe what happened</param>
+        /// <param name="exception">If relevant add the root cause exception</param>
+        public TelemetryValueException(string message, Exception exception)
+            : base(message, exception)
+        {
+        }
+    }
+}


### PR DESCRIPTION
### What
Changed how cache misses are handled
Resolved TelemetryClient metrics silently failing when dimensions are set to `string.Empty`

### Why
Due to an unhandled exception in the RedisTwinMappingIndexer that was fixed in the latest nuget the Telemetry project currently is not reporting the cache misses because the exception it was looking for is no longer present. This uncovered another issue where metric dimensions set to `string.Empty` will silently fail. 

### How
Deployed to test environment and observed the fixes working