### PR TITLE
[DevOps] Add Mapped to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
+      - dependency-name: Mapped.*
     reviewers:
       - "Tyler-Angell"
       - "joebeernink"
@@ -82,6 +83,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
+      - dependency-name: Mapped.*
     reviewers:
       - "Tyler-Angell"
       - "joebeernink"
@@ -92,6 +94,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
+      - dependency-name: Mapped.*
     reviewers:
       - "Tyler-Angell"
       - "joebeernink"
@@ -102,6 +105,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
+      - dependency-name: Mapped.*
     reviewers:
       - "Tyler-Angell"
       - "joebeernink"


### PR DESCRIPTION
### What
Watch for changes to Mapped Nugets

### Why
Lets us know when new changes have been made to Mapped Nugets which is important for remaining in sync with Mapped.