### PR TITLE
Adding an option for a client secret to use in a ClientSecretCredential

### DIFF
--- a/ADTTools/UploadModels/Options.cs
+++ b/ADTTools/UploadModels/Options.cs
@@ -11,6 +11,9 @@ namespace UploadModels
         [Option('c', "clientId", SetName = "upload", Required = true, HelpText = "The application's client id for connecting to Azure Digital Twins.")]
         public string ClientId { get; set; }
 
+        [Option('s', "clientSecret", SetName = "upload", Required = false, HelpText = "The application's client secret for connecting to Azure Digital Twins.")]
+        public string ClientSecret { get; set; }
+
         [Option('h', "hostName", SetName = "upload", Required = true, HelpText = "The host name of your Azure Digital Twins instance.")]
         public string HostName { get; set; }
 

--- a/ADTTools/UploadModels/Program.cs
+++ b/ADTTools/UploadModels/Program.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.Core;
 
 namespace UploadModels
 {
@@ -81,7 +82,16 @@ namespace UploadModels
             Log.Write("Uploaded interfaces:");
             try
             {
-                var credential = new InteractiveBrowserCredential(options.TenantId, options.ClientId);
+                TokenCredential credential;
+                if (string.IsNullOrEmpty(options.ClientSecret))
+                {
+                    credential = new InteractiveBrowserCredential(options.TenantId, options.ClientId);
+                }
+                else
+                {
+                    credential = new ClientSecretCredential(options.TenantId, options.ClientId, options.ClientSecret);
+                }
+
                 var client = new DigitalTwinsClient(new UriBuilder("https", options.HostName).Uri, credential);
 
                 for (int i = 0; i < (orderedInterfaces.Count() / options.BatchSize) + 1; i++)


### PR DESCRIPTION
When using an application registration to authenticate, the usage of the `InteractiveBrowserCredential` only works if this application registration is used to authenticate a user, and that user is then used to gain access to the ADT instance. But when using this application registration as the actual authenticator (with _id_ and _secret_), we need to use the `ClientSecretCredential` instead. To allow for this, a new new `ClientSecret` configuration option is added which triggers the usage of the `ClientSecretCredential`.