### PR TITLE
Reverting to Old DTDL Parser for OntologyManager

### DIFF
--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/IOntologyMappingManager.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/IOntologyMappingManager.cs
@@ -6,8 +6,8 @@
 
 namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
 {
-    using DTDLParser;
-    using DTDLParser.Models;
+    using Microsoft.Azure.DigitalTwins.Parser;
+    using Microsoft.Azure.DigitalTwins.Parser.Models;
 
     /// <summary>
     /// Defines the methods to be implemented by an OntologyMappingManager.

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.7.1</AssemblyVersion>
-		<PackageVersion>0.7.1-preview</PackageVersion>
+		<AssemblyVersion>0.7.2</AssemblyVersion>
+		<PackageVersion>0.7.2-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -23,7 +23,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="DTDLParser" Version="1.0.12-preview-ge5017bcd00" />
+		<PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMappingManager.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMappingManager.cs
@@ -7,8 +7,8 @@
 namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
 {
     using System.Text.RegularExpressions;
-    using DTDLParser;
-    using DTDLParser.Models;
+    using Microsoft.Azure.DigitalTwins.Parser;
+    using Microsoft.Azure.DigitalTwins.Parser.Models;
 
     /// <summary>
     /// Implements methods for consuming ontology mappings, i.e., to fetch ontology names (DTMIs, relationship names,

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMappingManagerTests.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMappingManagerTests.cs
@@ -4,8 +4,8 @@
 namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
 {
     using System.Reflection;
-    using DTDLParser;
-    using DTDLParser.Models;
+    using Microsoft.Azure.DigitalTwins.Parser;
+    using Microsoft.Azure.DigitalTwins.Parser.Models;
     using Microsoft.SmartPlaces.Facilities.OntologyMapper;
     using Moq;
     using Xunit;
@@ -435,7 +435,7 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
 
         private static IReadOnlyDictionary<Dtmi, DTEntityInfo> GetTargetObjectModel()
         {
-            var objectModelParser = new ModelParser(new ParsingOptions() { AllowUndefinedExtensions = true });
+            var objectModelParser = new ModelParser();
             var jsonTexts = LoadDtdl("Space.json");
             return objectModelParser.Parse(jsonTexts);
         }


### PR DESCRIPTION
### What
Reverting to the old DTDLParser

### Why
Having the new one (which is buggy), mixed in with the new one causes issues when updating and building.

### Tested
Built locally
Packaged
Used app to link to new package and verified it worked.