### PR TITLE
Add Mapping for ExternalID to Willow Ontology Mapping

### DIFF
--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -4771,6 +4771,12 @@
       "OutputPropertyName": "externalIds",
       "InputPropertyNames": [ "mappingKey" ],
       "IsOutputPropertyCollection": true
+    },
+    {
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "externalID",
+      "InputPropertyNames": [ "id" ],
+      "IsOutputPropertyCollection": false
     }
   ],
   "FillProperties": [

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one Mapped Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.10.2</AssemblyVersion>
-		<PackageVersion>0.10.2-preview</PackageVersion>
+		<AssemblyVersion>0.10.7</AssemblyVersion>
+		<PackageVersion>0.10.7-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
### What
Adding a mapping to the externalId field in the Willow Ontology to duplicate the TwinId as this supports backwards compatibility with older apps at WIllow.

### Why
Some apps depend on having a "twinId" stored in the externalID field. 

### Tested
Ran locally and the externalID field is now populated in the Willow ADT instance.