### PR TITLE
Add error handling to the Upload Models app

### DIFF
--- a/ADTTools/UploadModels/UploadModels.csproj
+++ b/ADTTools/UploadModels/UploadModels.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="1.9.0-beta.2" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Glob.cs" Version="5.1.1198" />
-    <PackageReference Include="DTDLParser" Version="1.0.37-preview-g0f8f3131c8" />
+    <PackageReference Include="DTDLParser" Version="1.0.52" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### What
Add error handling to the Upload Models app

### Why
If a model exists, don't cause the job to stop. Let it load the rest of the models. Works best when the batch size is set to 1

### Tested
Ran multiple times locally against ADT instances