### PR TITLE
Allow for new relationship names

### DIFF
--- a/SmartPlaces.Facilities/lib/IngestionManager/src/DefaultGraphNamingManager.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/DefaultGraphNamingManager.cs
@@ -1,0 +1,29 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="DefaultGraphNamingManager.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.SmartPlaces.Facilities.IngestionManager
+{
+    using Microsoft.SmartPlaces.Facilities.IngestionManager.Interfaces;
+
+    /// <summary>
+    /// Default naming for the output graph.
+    /// </summary>
+    public class DefaultGraphNamingManager : IGraphNamingManager
+    {
+        /// <summary>
+        /// Gets the name of the relationship in the output graph. Note that the default version does not use the properties argument.
+        /// </summary>
+        /// <param name="sourceTwinId">The twin id of the source twin.</param>
+        /// <param name="targetTwinId">The twin id of the target twin.</param>
+        /// <param name="relationshipType">The type of the relationship.</param>
+        /// <param name="properties">The propertie of the relationship to be encoded into the name.</param>
+        /// <returns>A formatted string that represents the relationship.</returns>
+        public string GetRelationshipName(string sourceTwinId, string targetTwinId, string relationshipType, IDictionary<string, object> properties)
+        {
+            return $"{sourceTwinId}-{targetTwinId}-{relationshipType}";
+        }
+    }
+}

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/Extensions/ServiceCollectionExtensions.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/Extensions/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Extensions
                 options.DefaultRequestHeaders.Add("ms-smartfacilities-version", Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0");
             });
 
+            services.AddSingleton<IGraphNamingManager, DefaultGraphNamingManager>();
             services.AddSingleton<IOutputGraphManager, AzureDigitalTwinsGraphManager<TOptions>>();
             return services;
         }

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>This is library injects data from one DTDL based graph, then converts and inserts the data into another DTDL base graph.</Description>
-		<AssemblyVersion>0.4.2</AssemblyVersion>
-		<PackageVersion>0.4.2-preview</PackageVersion>
+		<AssemblyVersion>0.5.3</AssemblyVersion>
+		<PackageVersion>0.5.3-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionProcessorBase.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionProcessorBase.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager
         private readonly MetricIdentifier targetDtmiNotFoundMetricIdentifier = new MetricIdentifier(Metrics.DefaultNamespace, "TargetDtmiNotFound", Metrics.InterfaceTypeDimensionName);
         private readonly MetricIdentifier outputMappingForInputDtmiNotFoundMetricIdentifier = new MetricIdentifier(Metrics.DefaultNamespace, "OutputMappingForInputDtmiNotFound", Metrics.OutputDtmiTypeDimensionName);
         private readonly MetricIdentifier mappingForInputDtmiNotFoundMetricIdentifier = new MetricIdentifier(Metrics.DefaultNamespace, "MappingForInputDtmiNotFound", Metrics.InterfaceTypeDimensionName);
-        private readonly IGraphNamingManager graphNaming;
+        private readonly IGraphNamingManager graphNamingManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IngestionProcessorBase{TOptions}"/> class.
@@ -42,13 +42,13 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager
         /// <param name="inputGraphManager">Manager for the input data graph that this ingestion processor parses.</param>
         /// <param name="ontologyMappingManager">Manager mapping between ontologies used by the input and output graphs.</param>
         /// <param name="outputGraphManager">Manager for the output data graph that this ingestion processor writes to.</param>
-        /// <param name="graphNaming">Manager for the naming of the elements of the graph.</param>
+        /// <param name="graphNamingManager">Manager for the naming of the elements of the graph.</param>
         /// <param name="telemetryClient">Application Insights telemetry client for remote metrics tracking.</param>
         protected IngestionProcessorBase(ILogger<IngestionProcessorBase<TOptions>> logger,
                                         IInputGraphManager inputGraphManager,
                                         IOntologyMappingManager ontologyMappingManager,
                                         IOutputGraphManager outputGraphManager,
-                                        IGraphNamingManager graphNaming,
+                                        IGraphNamingManager graphNamingManager,
                                         TelemetryClient telemetryClient)
         {
             Logger = logger;
@@ -57,7 +57,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager
             OntologyMappingManager = ontologyMappingManager;
             TargetModelParser = new ModelParser();
             OutputGraphManager = outputGraphManager;
-            this.graphNaming = graphNaming;
+            this.graphNamingManager = graphNamingManager;
         }
 
         /// <summary>
@@ -471,8 +471,8 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager
                         if (outputSourceDtmi != null && TargetObjectModel.TryGetValue(outputSourceDtmi, out var model))
                         {
                             var relationship = ((DTInterfaceInfo)model).Contents.FirstOrDefault(p => p.Value.EntityKind == DTEntityKind.Relationship && p.Value.Name == outputRelationship.Item1);
-                            var relationshipId = outputRelationship.Item2 ? graphNaming.GetRelationshipName(targetDtId, sourceDtId, outputRelationship.Item1, relationshipProperties) :
-                                                                            graphNaming.GetRelationshipName(sourceDtId, targetDtId, outputRelationship.Item1, relationshipProperties);
+                            var relationshipId = outputRelationship.Item2 ? graphNamingManager.GetRelationshipName(targetDtId, sourceDtId, outputRelationship.Item1, relationshipProperties) :
+                                                                            graphNamingManager.GetRelationshipName(sourceDtId, targetDtId, outputRelationship.Item1, relationshipProperties);
 
                             // Create a basic relationship
                             var basicRelationship = new BasicRelationship

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/Interfaces/IGraphNamingManager.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/Interfaces/IGraphNamingManager.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="IGraphNamingManager.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Interfaces
+{
+    /// <summary>
+    /// Injectable interface to allow for custom naming entities in the output graph.
+    /// </summary>
+    public interface IGraphNamingManager
+    {
+        /// <summary>
+        /// Gets the name of the relationship in the output graph.
+        /// </summary>
+        /// <param name="sourceTwinId">The twin id of the source twin.</param>
+        /// <param name="targetTwinId">The twin id of the target twin.</param>
+        /// <param name="relationshipType">The type of the relationship.</param>
+        /// <param name="properties">The properties of the relationship to be encoded into the name.</param>
+        /// <returns>A formatted string that represents the relationship.</returns>
+        public string GetRelationshipName(string sourceTwinId, string targetTwinId, string relationshipType, IDictionary<string, object> properties);
+    }
+}

--- a/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionProcessorBaseTests.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionProcessorBaseTests.cs
@@ -81,6 +81,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
             await mockedIngestionProcessor.IngestFromApiAsync(CancellationToken.None);
         }
@@ -92,6 +93,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var dtmi = mockedIngestionProcessor.TestInputInterfaceDtmi("invalidType");
@@ -105,6 +107,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var dtmi = mockedIngestionProcessor.TestInputInterfaceDtmi("Space");
@@ -118,6 +121,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var expectedRelationshipType = "isA";
@@ -133,6 +137,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var inputRelationshipType = "wasA";
@@ -147,6 +152,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var inputDtmi = new Dtmi("dtmi:org:w3id:rec:Space;1");
@@ -165,6 +171,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var inputDtmi = new Dtmi("dtmi:twin:main:CleaningRoom;1");
@@ -184,6 +191,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var inputDtmi = new Dtmi("dtmi:twin:main:SpaceShip;1");
@@ -201,6 +209,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             await mockedIngestionProcessor.IngestFromApiAsync(CancellationToken.None);
@@ -220,6 +229,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             await mockedIngestionProcessor.IngestFromApiAsync(CancellationToken.None);
@@ -239,6 +249,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var expectedDtmi = "dtmi:org:w3id:rec:Space;1";
@@ -266,6 +277,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var expectedDtmi = "dtmi:org:w3id:rec:Space;1";
@@ -293,6 +305,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var expectedDtmi = "dtmi:org:w3id:rec:SpaceWithBox;1";
@@ -321,6 +334,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var expectedDtmi = "dtmi:org:w3id:rec:Space;1";
@@ -352,6 +366,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             var expectedDtmi = "dtmi:org:w3id:rec:Space;1";
@@ -384,6 +399,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             IDictionary<string, BasicRelationship> relationships = new Dictionary<string, BasicRelationship>();
@@ -392,10 +408,14 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             var inputRelationshipType = "isLocationOf";
             string targetDtId = "CLSKkDFMgbojZZ54MorD6B11R";
             string targetInterfaceType = "Space";
+            IDictionary<string, object> relationshipProperties = new Dictionary<string, object>
+            {
+                { "testKey", "testValue" }
+            };
 
             await mockedIngestionProcessor.IngestFromApiAsync(CancellationToken.None);
 
-            mockedIngestionProcessor.TestGetRelationship(relationships, sourceDtId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType);
+            mockedIngestionProcessor.TestGetRelationship(relationships, sourceDtId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType, relationshipProperties);
 
             Assert.Single(relationships);
             var outputRelationship = relationships.First();
@@ -406,6 +426,8 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(targetDtId, outputRelationship.Value.TargetId);
             Assert.Equal($"{sourceDtId}-{targetDtId}-{outputRelationship.Value.Name}", outputRelationship.Value.Id);
             Assert.NotNull(outputRelationship.Value.Id);
+            Assert.Equal("testKey", outputRelationship.Value.Properties.First().Key);
+            Assert.Equal("testValue", outputRelationship.Value.Properties.First().Value);
         }
 
         [Fact]
@@ -415,6 +437,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             IDictionary<string, BasicRelationship> relationships = new Dictionary<string, BasicRelationship>();
@@ -423,12 +446,13 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             var inputRelationshipType = "hasA";
             string targetDtId = "CLSKkDFMgbojZZ54MorD6B11R";
             string targetInterfaceType = "Space";
+            IDictionary<string, object> relationshipProperties = new Dictionary<string, object>();
 
             var expectedRelationshipType = "isA";
 
             await mockedIngestionProcessor.IngestFromApiAsync(CancellationToken.None);
 
-            mockedIngestionProcessor.TestGetRelationship(relationships, sourceDtId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType);
+            mockedIngestionProcessor.TestGetRelationship(relationships, sourceDtId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType, relationshipProperties);
 
             Assert.Single(relationships);
             var outputRelationship = relationships.First();
@@ -448,6 +472,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                                                         telemetryClient,
                                                                         mockInputGraphManager.Object,
                                                                         ontologyMappingManager,
+                                                                        new DefaultGraphNamingManager(),
                                                                         mockOutputGraphManager.Object);
 
             IDictionary<string, BasicRelationship> relationships = new Dictionary<string, BasicRelationship>();
@@ -456,12 +481,13 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             var inputRelationshipType = "hasPoint";
             string targetDtId = "CLSKkDFMgbojZZ54MorD6B11R";
             string targetInterfaceType = "Space";
+            IDictionary<string, object> relationshipProperties = new Dictionary<string, object>();
 
             var expectedRelationshipType = "isPointOf";
 
             await mockedIngestionProcessor.IngestFromApiAsync(CancellationToken.None);
 
-            mockedIngestionProcessor.TestGetRelationship(relationships, sourceDtId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType);
+            mockedIngestionProcessor.TestGetRelationship(relationships, sourceDtId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType, relationshipProperties);
 
             Assert.Single(relationships);
             var outputRelationship = relationships.First();
@@ -548,8 +574,9 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
                                         TelemetryClient telemetryClient,
                                         IInputGraphManager inputGraphManager,
                                         IOntologyMappingManager ontologyMappingManager,
+                                        IGraphNamingManager graphNamingManager,
                                         IOutputGraphManager outputGraphManager)
-            : base(logger, inputGraphManager, ontologyMappingManager, outputGraphManager, telemetryClient)
+            : base(logger, inputGraphManager, ontologyMappingManager, outputGraphManager, graphNamingManager, telemetryClient)
         {
         }
 
@@ -577,13 +604,14 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
         }
 
         public void TestGetRelationship(IDictionary<string, BasicRelationship> relationships,
-                              string? sourceElementId,
+                              string sourceElementId,
                               Dtmi? inputSourceDtmi,
                               string? inputRelationshipType,
                               string targetDtId,
-                              string targetInterfaceType)
+                              string targetInterfaceType,
+                              IDictionary<string, object> relationshipProperties)
         {
-            AddRelationship(relationships, sourceElementId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType);
+            AddRelationship(relationships, sourceElementId, inputSourceDtmi, inputRelationshipType, targetDtId, targetInterfaceType, relationshipProperties);
         }
 
         protected override Task ProcessSites(CancellationToken cancellationToken)


### PR DESCRIPTION
### What
Allow a formatter class to be passed in by the consumer to allow a custom algorithm for setting the relationship Id

### Why
1. Willow has a different naming convention for relationship ids
2. It is possible to have multiple relationships between two entities of the same type that differ by a property.
i.,e. a waterpump could feed both hot and cold water to a system, and we might want to have a isFedBy for HotWater, and for cold water for the twins.

### Tested
- Ran unit tests
- Integrated with the IntegrationManager.Mapped locally and ran those tests. Will have a separate PR for those changes once this PR completes.