### PR TITLE
Fix interface remaps

### DIFF
--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v0/BrickRec/mapped_json_v0_dtdlv2_Brick_1_3-REC_4_0.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v0/BrickRec/mapped_json_v0_dtdlv2_Brick_1_3-REC_4_0.json
@@ -184,8 +184,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:AirQualitySensingDevice;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Quality_Sensing_Device;1",
+      "OutputDtmi": "dtmi:mapped:core:Air_Quality_Sensing_Device;1",
       "IsIgnored": true
     },
     {
@@ -327,14 +326,12 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:BACnetObjectId;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:BACnet_Object_Id;1",
+      "OutputDtmi": "dtmi:mapped:core:BACnet_Object_Id;1",
       "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:BACnetVendorId;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:BACnet_Vendor_Id;1",
+      "OutputDtmi": "dtmi:mapped:core:BACnet_Vendor_Id;1",
       "IsIgnored": true
     },
     {
@@ -467,21 +464,13 @@
       "OutputDtmi": "dtmi:org:w3id:rec:CafeteriaRoom;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Calendar;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:CalendarEvent;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar_Event;1",
+      "OutputDtmi": "dtmi:mapped:core:Calendar_Event;1",
       "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:CalendarEventInvitation;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar_Event_Invitation;1",
+      "OutputDtmi": "dtmi:mapped:core:Calendar_Event_Invitation;1",
       "IsIgnored": true
     },
     {
@@ -658,12 +647,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:Chiller;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Chiller;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Class;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Class;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:CloseLimit;1",
@@ -1179,8 +1162,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:DirectExpansionUnit;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Direct_Expansion_Unit;1",
+      "OutputDtmi": "dtmi:mapped:core:Direct_Expansion_Unit;1",
       "IsIgnored": true
     },
     {
@@ -1398,12 +1380,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Displacement_Flow_Air_Diffuser;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Display;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Display;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:DisplayResolutionStatus;1",
       // Mapped to Base - Review needed
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Status;1"
@@ -1579,15 +1555,8 @@
       "OutputDtmi": "dtmi:org:w3id:rec:ElevatorRoom;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Email;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Email;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:EmailIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Email_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Email_Identity;1",
       "IsIgnored": true
     },
     {
@@ -1786,12 +1755,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:EvenMonthStatus;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Even_Month_Status;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Event;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Event;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:ExerciseRoom;1",
@@ -2018,8 +1981,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:FloorLevelIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Floor_Level_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Floor_Level_Identity;1",
       "IsIgnored": true
     },
     {
@@ -2539,12 +2501,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Ice_Tank_Leaving_Water_Temperature_Sensor;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Identity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Identity;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:IDF;1",
       // Invalid Output DTMI - Review Needed
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:IDF;1",
@@ -2676,7 +2632,7 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Water_Temperature_Setpoint;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Library;1",
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Library;1",
       "OutputDtmi": "dtmi:org:w3id:rec:Library;1"
     },
     {
@@ -2774,12 +2730,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:Lounge;1",
       "OutputDtmi": "dtmi:org:w3id:rec:RecreationalRoom;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Louver;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Louver;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:LowAirFlowAlarm;1",
@@ -3136,12 +3086,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Meta;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Meta;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:Meter;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Meter;1"
     },
@@ -3367,8 +3311,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:NameIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Name_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Name_Identity;1",
       "IsIgnored": true
     },
     {
@@ -3571,12 +3514,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Opening;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Opening;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:OpenOffice;1",
       "OutputDtmi": "dtmi:org:w3id:rec:OfficeRoom;1"
     },
@@ -3755,8 +3692,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:PersonProfile;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Person_Profile;1",
+      "OutputDtmi": "dtmi:mapped:core:Person_Profile;1",
       "IsIgnored": true
     },
     {
@@ -3781,8 +3717,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:PlugStrip;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Plug_Strip;1",
+      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:PlugStrip;1",
       "IsIgnored": true
     },
     {
@@ -3837,8 +3772,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:PostalAddressIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Postal_Address_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Postal_Address_Identity;1",
       "IsIgnored": true
     },
     {
@@ -3976,14 +3910,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:ProjectionScreen;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Projection_Screen;1",
-      "IsIgnored": true
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:PropertyBag;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Property_Bag;1",
+      "OutputDtmi": "dtmi:mapped:core:Projection_Screen;1",
       "IsIgnored": true
     },
     {
@@ -4151,12 +4078,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:RemotelyOnOffStatus;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Remotely_On_Off_Status;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Request;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Request;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:ResetCommand;1",
@@ -4487,20 +4408,8 @@
       "OutputDtmi": "dtmi:org:w3id:rec:Space;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:SpaceCode;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Space_Code;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:SpaceHeater;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Space_Heater;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Speaker;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Speaker;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:SpeedCommand;1",
@@ -4540,9 +4449,9 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:StageRiser;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Stage_Riser;1",
+      "OutputDtmi": "dtmi:mapped:core:Stage_Riser;1",
       "IsIgnored": true
+
     },
     {
       "InputDtmi": "dtmi:mapped:core:StagesStatus;1",
@@ -4893,8 +4802,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:TeleconferenceUnit;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Teleconference_Unit;1",
+      "OutputDtmi": "dtmi:mapped:core:Teleconference_Unit;1",
       "IsIgnored": true
     },
     {
@@ -4960,7 +4868,7 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Terminal_Unit;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:TestPoint;1",
+      "InputDtmi": "dtmi:mapped:core:Test_Point;1",
       // Mapped to Base - Review needed
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Point;1"
     },

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v0/BrickRec/mapped_json_v0_dtdlv3_Brick_1_3-REC_4_0.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v0/BrickRec/mapped_json_v0_dtdlv3_Brick_1_3-REC_4_0.json
@@ -185,8 +185,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:AirQualitySensingDevice;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Quality_Sensing_Device;1",
+      "OutputDtmi": "dtmi:mapped:core:Air_Quality_Sensing_Device;1",
       "IsIgnored": true
     },
     {
@@ -328,14 +327,12 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:BACnetObjectId;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:BACnet_Object_Id;1",
+      "OutputDtmi": "dtmi:mapped:core:BACnet_Object_Id;1",
       "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:BACnetVendorId;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:BACnet_Vendor_Id;1",
+      "OutputDtmi": "dtmi:mapped:core:BACnet_Vendor_Id;1",
       "IsIgnored": true
     },
     {
@@ -468,21 +465,13 @@
       "OutputDtmi": "dtmi:org:w3id:rec:CafeteriaRoom;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Calendar;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:CalendarEvent;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar_Event;1",
+      "OutputDtmi": "dtmi:mapped:core:Calendar_Event;1",
       "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:CalendarEventInvitation;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar_Event_Invitation;1",
+      "OutputDtmi": "dtmi:mapped:core:Calendar_Event_Invitation;1",
       "IsIgnored": true
     },
     {
@@ -659,12 +648,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:Chiller;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Chiller;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Class;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Class;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:CloseLimit;1",
@@ -1180,8 +1163,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:DirectExpansionUnit;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Direct_Expansion_Unit;1",
+      "OutputDtmi": "dtmi:mapped:core:Direct_Expansion_Unit;1",
       "IsIgnored": true
     },
     {
@@ -1399,12 +1381,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Displacement_Flow_Air_Diffuser;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Display;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Display;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:DisplayResolutionStatus;1",
       // Mapped to Base - Review needed
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Status;1"
@@ -1580,15 +1556,8 @@
       "OutputDtmi": "dtmi:org:w3id:rec:ElevatorRoom;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Email;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Email;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:EmailIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Email_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Email_Identity;1",
       "IsIgnored": true
     },
     {
@@ -1787,12 +1756,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:EvenMonthStatus;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Even_Month_Status;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Event;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Event;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:ExerciseRoom;1",
@@ -2019,8 +1982,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:FloorLevelIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Floor_Level_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Floor_Level_Identity;1",
       "IsIgnored": true
     },
     {
@@ -2540,12 +2502,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Ice_Tank_Leaving_Water_Temperature_Sensor;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Identity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Identity;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:IDF;1",
       // Invalid Output DTMI - Review Needed
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:IDF;1",
@@ -2775,12 +2731,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:Lounge;1",
       "OutputDtmi": "dtmi:org:w3id:rec:RecreationalRoom;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Louver;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Louver;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:LowAirFlowAlarm;1",
@@ -3137,12 +3087,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Meta;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Meta;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:Meter;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Meter;1"
     },
@@ -3368,8 +3312,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:NameIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Name_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Name_Identity;1",
       "IsIgnored": true
     },
     {
@@ -3572,12 +3515,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Opening;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Opening;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:OpenOffice;1",
       "OutputDtmi": "dtmi:org:w3id:rec:OfficeRoom;1"
     },
@@ -3756,8 +3693,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:PersonProfile;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Person_Profile;1",
+      "OutputDtmi": "dtmi:mapped:core:Person_Profile;1",
       "IsIgnored": true
     },
     {
@@ -3782,8 +3718,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:PlugStrip;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Plug_Strip;1",
+      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:PlugStrip;1",
       "IsIgnored": true
     },
     {
@@ -3838,8 +3773,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:PostalAddressIdentity;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Postal_Address_Identity;1",
+      "OutputDtmi": "dtmi:mapped:core:Postal_Address_Identity;1",
       "IsIgnored": true
     },
     {
@@ -3977,14 +3911,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:ProjectionScreen;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Projection_Screen;1",
-      "IsIgnored": true
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:PropertyBag;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Property_Bag;1",
+      "OutputDtmi": "dtmi:mapped:core:Projection_Screen;1",
       "IsIgnored": true
     },
     {
@@ -4152,12 +4079,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:RemotelyOnOffStatus;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Remotely_On_Off_Status;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Request;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Request;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:ResetCommand;1",
@@ -4488,20 +4409,8 @@
       "OutputDtmi": "dtmi:org:w3id:rec:Space;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:SpaceCode;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Space_Code;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:SpaceHeater;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Space_Heater;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Speaker;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Speaker;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:SpeedCommand;1",
@@ -4541,8 +4450,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:StageRiser;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Stage_Riser;1",
+      "OutputDtmi": "dtmi:mapped:core:Stage_Riser;1",
       "IsIgnored": true
     },
     {
@@ -4894,8 +4802,7 @@
     },
     {
       "InputDtmi": "dtmi:mapped:core:TeleconferenceUnit;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Teleconference_Unit;1",
+      "OutputDtmi": "dtmi:mapped:core:Teleconference_Unit;1",
       "IsIgnored": true
     },
     {
@@ -4961,7 +4868,7 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Terminal_Unit;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:TestPoint;1",
+      "InputDtmi": "dtmi:mapped:core:Test_Point;1",
       // Mapped to Base - Review needed
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Point;1"
     },

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v0/Willow/mapped_json_v0_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v0/Willow/mapped_json_v0_dtdlv2_Willow.json
@@ -2197,7 +2197,7 @@
       "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Library;1",
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Library;1",
       "OutputDtmi": "dtmi:com:willowinc:Library;1",
       "IsIgnored": true
     },
@@ -4148,7 +4148,7 @@
       "OutputDtmi": "dtmi:com:willowinc:State;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:TestPoint;1",
+      "InputDtmi": "dtmi:mapped:core:Test_Point;1",
       "OutputDtmi": "dtmi:com:willowinc:Capability;1",
       "IsIgnored": true
     },

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/BrickRec/mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/BrickRec/mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json
@@ -73,12 +73,6 @@
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Status;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Direct_Expansion_Unit;1",
-      // Invalid Output DTMI - Review Needed
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Direct_Expansion_Unit;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:Discharge_Air_Temperature_Reset_Setpoint;1",
       // Temporary until further decision with Brick
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Reset_Setpoint;1"

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/BrickRec/mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/BrickRec/mapped_v1_dtdlv2_Brick_1_3-REC_4_0.json
@@ -415,10 +415,6 @@
       "OutputDtmi": "dtmi:org:w3id:rec:OfficeRoom;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Operating_Mode_Status;1",
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Operating_Mode_Status;1"
-    },
-    {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outdoor_Area;1",
       "OutputDtmi": "dtmi:org:w3id:rec:Space;1"
     },

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -368,7 +368,7 @@
       "OutputDtmi": "dtmi:com:willowinc:State;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Library;1",
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Library;1",
       "OutputDtmi": "dtmi:com:willowinc:Library;1",
       "IsIgnored": true
     },
@@ -687,7 +687,7 @@
       "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:TestPoint;1",
+      "InputDtmi": "dtmi:mapped:core:Test_Point;1",
       "OutputDtmi": "dtmi:com:willowinc:Capability;1",
       "IsIgnored": true
     },
@@ -806,7 +806,7 @@
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Quality_Sensing_Device;1",
+      "InputDtmi": "dtmi:mapped:core:Air_Quality_Sensing_Device;1",
       "OutputDtmi": "dtmi:com:willowinc:Device;1",
       "IsIgnored": true
     },
@@ -904,12 +904,12 @@
       "OutputDtmi": "dtmi:com:willowinc:ZoneAirTemperatureSensor;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:BACnet_Object_Id;1",
+      "InputDtmi": "dtmi:mapped:core:BACnet_Object_Id;1",
       "OutputDtmi": "dtmi:com:willowinc:BACnetObjectId;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:BACnet_Vendor_Id;1",
+      "InputDtmi": "dtmi:mapped:core:BACnet_Vendor_Id;1",
       "OutputDtmi": "dtmi:com:willowinc:BACnetVendorId;1",
       "IsIgnored": true
     },
@@ -1069,17 +1069,17 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar;1",
+      "InputDtmi": "dtmi:mapped:core:Calendar;1",
       "OutputDtmi": "dtmi:com:willowinc:Calendar;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar_Event;1",
+      "InputDtmi": "dtmi:mapped:core:Calendar_Event;1",
       "OutputDtmi": "dtmi:com:willowinc:Event;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Calendar_Event_Invitation;1",
+      "InputDtmi": "dtmi:mapped:core:Calendar_Event_Invitation;1",
       "OutputDtmi": "dtmi:com:willowinc:CalendarEventInvitation;1",
       "IsIgnored": true
     },
@@ -1170,7 +1170,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Valve;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Class;1",
+      "InputDtmi": "dtmi:mapped:core:Class;1",
       "OutputDtmi": "dtmi:com:willowinc:Class;1",
       "IsIgnored": true
     },
@@ -1179,17 +1179,17 @@
       "OutputDtmi": "dtmi:com:willowinc:Limit;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cloud_Layer1_Height_Code_Sensor;1",
+      "InputDtmi": "dtmi:mapped:core:Cloud_Layer_1_Height_Code_Sensor;1",
       "OutputDtmi": "dtmi:com:willowinc:CloudLayer1HeightCodeSensor;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cloud_Layer2_Height_Code_Sensor;1",
+      "InputDtmi": "dtmi:mapped:core:Cloud_Layer_2_Height_Code_Sensor;1",
       "OutputDtmi": "dtmi:com:willowinc:CloudLayer2HeightCodeSensor;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cloud_Layer3_Height_Code_Sensor;1",
+      "InputDtmi": "dtmi:mapped:core:Cloud_Layer_3_Height_Code_Sensor;1",
       "OutputDtmi": "dtmi:com:willowinc:CloudLayer3HeightCodeSensor;1",
       "IsIgnored": true
     },
@@ -1537,7 +1537,7 @@
       "OutputDtmi": "dtmi:com:willowinc:FanCoilUnit;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Direct_Expansion_Unit;1",
+      "InputDtmi": "dtmi:mapped:core:Direct_Expansion_Unit;1",
       "OutputDtmi": "dtmi:com:willowinc:DirectExpansionUnit;1",
       "IsIgnored": true
     },
@@ -1690,7 +1690,7 @@
       "OutputDtmi": "dtmi:com:willowinc:AirDiffuser;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Display;1",
+      "InputDtmi": "dtmi:mapped:core:Display;1",
       "OutputDtmi": "dtmi:com:willowinc:Display;1",
       "IsIgnored": true
     },
@@ -1804,12 +1804,12 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Email;1",
+      "InputDtmi": "dtmi:mapped:core:Email;1",
       "OutputDtmi": "dtmi:com:willowinc:Email;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Email_Identity;1",
+      "InputDtmi": "dtmi:mapped:core:Email_Identity;1",
       "OutputDtmi": "dtmi:com:willowinc:EmailIdentity;1",
       "IsIgnored": true
     },
@@ -1971,7 +1971,7 @@
       "OutputDtmi": "dtmi:com:willowinc:State;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Event;1",
+      "InputDtmi": "dtmi:mapped:core:Event;1",
       "OutputDtmi": "dtmi:com:willowinc:Event;1",
       "IsIgnored": true
     },
@@ -2044,12 +2044,12 @@
       "OutputDtmi": "dtmi:com:willowinc:ExhaustFan;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Fan_Disable_Command;1",
+      "InputDtmi": "dtmi:mapped:core:Exhaust_Fan_Disable_Command;1",
       "OutputDtmi": "dtmi:com:willowinc:DisableActuator;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Fan_Enable_Command;1",
+      "InputDtmi": "dtmi:mapped:core:Exhaust_Fan_Enable_Command;1",
       "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1",
       "IsIgnored": true
     },
@@ -2157,7 +2157,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Level;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Floor_Level_Identity;1",
+      "InputDtmi": "dtmi:mapped:core:Floor_Level_Identity;1",
       "OutputDtmi": "dtmi:com:willowinc:FloorLevelIdentity;1",
       "IsIgnored": true
     },
@@ -2535,7 +2535,7 @@
       "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterTemperatureSensor;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Identity;1",
+      "InputDtmi": "dtmi:mapped:core:Identity;1",
       "OutputDtmi": "dtmi:com:willowinc:Identity;1",
       "IsIgnored": true
     },
@@ -2700,7 +2700,7 @@
       "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lock_Unlock_Command;1",
+      "InputDtmi": "dtmi:mapped:core:Lock_Unlock_Command;1",
       "OutputDtmi": "dtmi:com:willowinc:OnOffActuator;1",
       "IsIgnored": true
     },
@@ -2722,7 +2722,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Louver;1",
+      "InputDtmi": "dtmi:mapped:core:Louver;1",
       "OutputDtmi": "dtmi:com:willowinc:Louver;1",
       "IsIgnored": true
     },
@@ -3005,7 +3005,7 @@
       "OutputDtmi": "dtmi:com:willowinc:HotWaterDeltaPressureSetpoint;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Meta;1",
+      "InputDtmi": "dtmi:mapped:core:Meta;1",
       "OutputDtmi": "dtmi:com:willowinc:Meta;1",
       "IsIgnored": true
     },
@@ -3204,7 +3204,7 @@
       "OutputDtmi": "dtmi:com:willowinc:NO2Sensor;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Name_Identity;1",
+      "InputDtmi": "dtmi:mapped:core:Name_Identity;1",
       "OutputDtmi": "dtmi:com:willowinc:NameIdentity;1",
       "IsIgnored": true
     },
@@ -3333,7 +3333,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Offset;1",
+      "InputDtmi": "dtmi:mapped:core:Offset;1",
       "OutputDtmi": "dtmi:com:willowinc:Setpoint;1",
       "IsIgnored": true
     },
@@ -3366,7 +3366,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Opening;1",
+      "InputDtmi": "dtmi:mapped:core:Opening;1",
       "OutputDtmi": "dtmi:com:willowinc:Opening;1",
       "IsIgnored": true
     },
@@ -3564,7 +3564,7 @@
       "OutputDtmi": "dtmi:com:willowinc:PowerSensor;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Person_Profile;1",
+      "InputDtmi": "dtmi:mapped:core:Person_Profile;1",
       "OutputDtmi": "dtmi:com:willowinc:PersonProfile;1",
       "IsIgnored": true
     },
@@ -3578,7 +3578,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Plug_Strip;1",
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PlugStrip;1",
       "OutputDtmi": "dtmi:com:willowinc:PlugStrip;1",
       "IsIgnored": true
     },
@@ -3599,7 +3599,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Limit;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Postal_Address_Identity;1",
+      "InputDtmi": "dtmi:mapped:core:Postal_Address_Identity;1",
       "OutputDtmi": "dtmi:com:willowinc:PostalAddressIdentity;1",
       "IsIgnored": true
     },
@@ -3672,12 +3672,12 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Projection_Screen;1",
+      "InputDtmi": "dtmi:mapped:core:Projection_Screen;1",
       "OutputDtmi": "dtmi:com:willowinc:ProjectionScreen;1",
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Property_Bag;1",
+      "InputDtmi": "dtmi:mapped:core:PropertyBag;1",
       "OutputDtmi": "dtmi:com:willowinc:PropertyBag;1",
       "IsIgnored": true
     },
@@ -3817,7 +3817,7 @@
       "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Request;1",
+      "InputDtmi": "dtmi:mapped:core:Request;1",
       "OutputDtmi": "dtmi:com:willowinc:Request;1",
       "IsIgnored": true
     },
@@ -3969,7 +3969,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Setpoint_Offset;1",
+      "InputDtmi": "dtmi:mapped:core:Setpoint_Offset;1",
       "OutputDtmi": "dtmi:com:willowinc:Setpoint;1",
       "IsIgnored": true
     },
@@ -4016,7 +4016,7 @@
       "IsIgnored": true
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Space_Code;1",
+      "InputDtmi": "dtmi:mapped:core:SpaceCode;1",
       "OutputDtmi": "dtmi:com:willowinc:SpaceCode;1",
       "IsIgnored": true
     },
@@ -4025,7 +4025,7 @@
       "OutputDtmi": "dtmi:com:willowinc:UnitHeater;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speaker;1",
+      "InputDtmi": "dtmi:mapped:core:Speaker;1",
       "OutputDtmi": "dtmi:com:willowinc:Speaker;1",
       "IsIgnored": true
     },
@@ -4062,7 +4062,7 @@
       "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Stage_Riser;1",
+      "InputDtmi": "dtmi:mapped:core:Stage_Riser;1",
       "OutputDtmi": "dtmi:com:willowinc:StageRiser;1",
       "IsIgnored": true
     },
@@ -4333,7 +4333,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Teleconference_Unit;1",
+      "InputDtmi": "dtmi:mapped:core:Teleconference_Unit;1",
       "OutputDtmi": "dtmi:com:willowinc:TeleconferenceUnit;1",
       "IsIgnored": true
     },
@@ -4386,7 +4386,7 @@
       "OutputDtmi": "dtmi:com:willowinc:State;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Test_Point;1",
+      "InputDtmi": "dtmi:mapped:core:Test_Point;1",
       "OutputDtmi": "dtmi:com:willowinc:Capability;1",
       "IsIgnored": true
     },
@@ -4412,7 +4412,7 @@
       "OutputDtmi": "dtmi:com:willowinc:Valve;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thing;1",
+      "InputDtmi": "dtmi:mapped:core:Thing;1",
       "OutputDtmi": "dtmi:com:willowinc:Equipment;1",
       "IsIgnored": true
     },

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -2521,16 +2521,6 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:IP_v4_Address;1",
-      "OutputDtmi": "dtmi:com:willowinc:IPv4Address;1",
-      "IsIgnored": true
-    },
-    {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:IP_v6_Address;1",
-      "OutputDtmi": "dtmi:com:willowinc:IPv6Address;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ice_Tank_Leaving_Water_Temperature_Sensor;1",
       "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterTemperatureSensor;1"
     },
@@ -2802,11 +2792,6 @@
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Luminance_Command;1",
       "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
-    },
-    {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:MAC_Address;1",
-      "OutputDtmi": "dtmi:com:willowinc:MACAddress;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:MAU;1",
@@ -4729,31 +4714,6 @@
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Unoccupied_Load_Shed_Command;1",
       "OutputDtmi": "dtmi:com:willowinc:UnoccupiedActuator;1"
-    },
-    {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:attachment;1",
-      "OutputDtmi": "dtmi:com:willowinc:attachment;1",
-      "IsIgnored": true
-    },
-    {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:callInfo;1",
-      "OutputDtmi": "dtmi:com:willowinc:callInfo;1",
-      "IsIgnored": true
-    },
-    {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:connected_Data_Source_Id;1",
-      "OutputDtmi": "dtmi:com:willowinc:connectedDataSourceId;1",
-      "IsIgnored": true
-    },
-    {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:firmware_Version;1",
-      "OutputDtmi": "dtmi:com:willowinc:firmwareVersion;1",
-      "IsIgnored": true
-    },
-    {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:postal_Code;1",
-      "OutputDtmi": "dtmi:com:willowinc:postalCode;1",
-      "IsIgnored": true
     }
   ],
   "RelationshipRemaps": [

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -465,11 +465,6 @@
       "OutputDtmi": "dtmi:com:willowinc:OccupiedHeatingSetpoint;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Offset;1",
-      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:Outside_Air_Temperature_Reset_Setpoint;1",
       "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
     },

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -2618,11 +2618,6 @@
       "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
     },
     {
-      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Library;1",
-      "OutputDtmi": "dtmi:com:willowinc:Library;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Light_Command;1",
       "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
     },
@@ -3937,11 +3932,6 @@
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Service_Room;1",
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Setpoint_Offset;1",
-      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Shading_System;1",

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -179,11 +179,6 @@
       "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Direct_Expansion_Unit;1",
-      "OutputDtmi": "dtmi:com:willowinc:DirectExpansionUnit;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:mapped:core:Discharge_Air_Temperature_Reset_Setpoint;1",
       "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
     },
@@ -680,11 +675,6 @@
     {
       "InputDtmi": "dtmi:mapped:core:Temperature_Alarm_Setpoint;1",
       "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Test_Point;1",
-      "OutputDtmi": "dtmi:com:willowinc:Capability;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:mapped:core:Thing;1",
@@ -4390,11 +4380,6 @@
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermostatic_Mixing_Valve;1",
       "OutputDtmi": "dtmi:com:willowinc:Valve;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Thing;1",
-      "OutputDtmi": "dtmi:com:willowinc:Equipment;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ticketing_Booth;1",

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -3934,6 +3934,11 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
+      "InputDtmi": "dtmi:mapped:core:Setpoint_Offset;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1",
+      "IsIgnored": true
+    },
+    {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Shading_System;1",
       "OutputDtmi": "dtmi:com:willowinc:ShadingSystem;1",
       "IsIgnored": true
@@ -4370,6 +4375,11 @@
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermostatic_Mixing_Valve;1",
       "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Thing;1",
+      "OutputDtmi": "dtmi:com:willowinc:Equipment;1",
+      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ticketing_Booth;1",

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -3934,11 +3934,6 @@
       "OutputDtmi": "dtmi:com:willowinc:Room;1"
     },
     {
-      "InputDtmi": "dtmi:mapped:core:Setpoint_Offset;1",
-      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1",
-      "IsIgnored": true
-    },
-    {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Shading_System;1",
       "OutputDtmi": "dtmi:com:willowinc:ShadingSystem;1",
       "IsIgnored": true
@@ -4375,11 +4370,6 @@
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermostatic_Mixing_Valve;1",
       "OutputDtmi": "dtmi:com:willowinc:Valve;1"
-    },
-    {
-      "InputDtmi": "dtmi:mapped:core:Thing;1",
-      "OutputDtmi": "dtmi:com:willowinc:Equipment;1",
-      "IsIgnored": true
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ticketing_Booth;1",

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one Mapped Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.10.9</AssemblyVersion>
-		<PackageVersion>0.10.9-preview</PackageVersion>
+		<AssemblyVersion>0.10.10</AssemblyVersion>
+		<PackageVersion>0.10.10-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one Mapped Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.10.10</AssemblyVersion>
-		<PackageVersion>0.10.10-preview</PackageVersion>
+		<AssemblyVersion>0.10.11</AssemblyVersion>
+		<PackageVersion>0.10.11-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
### What
- Aligned `InterfaceRemaps` with the Mapped ontology 
- Removed properties from `InterfaceRemaps`
### Why
- Some of the `InputDtmi` fields were referring to classes which don't exist in the Mapped ontology
- Properties don't belong in `InterfaceRemaps`
### Tested
Verified all `InputDtmi` fields exist in Mapped ontology