### PR TITLE
Fix issue with alternateClassification

### DIFF
--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -4787,12 +4787,6 @@
     },
     {
       "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "alternateClassification",
-      "InputPropertyNames": [ "exactType" ],
-      "IsOutputPropertyCollection": false
-    },
-    {
-      "OutputDtmiFilter": ".*",
       "OutputPropertyName": "externalID",
       "InputPropertyNames": [ "id" ],
       "IsOutputPropertyCollection": false

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one Mapped Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.10.9</AssemblyVersion>
-		<PackageVersion>0.10.9-preview</PackageVersion>
+		<AssemblyVersion>0.10.10</AssemblyVersion>
+		<PackageVersion>0.10.10-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
### What
Removed alternateClassification mapping,

### Why
The Willow ontology for this field is a json object, not a string, so the copy of the string is not compatible. Will need to do this another way.

### Tested
