### PR TITLE
Add ability to add custom properties to a twin based on the input twin

### DIFF
--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>This is library injects data from one DTDL based graph, then converts and inserts the data into another DTDL base graph.</Description>
-		<AssemblyVersion>0.5.4</AssemblyVersion>
-		<PackageVersion>0.5.4-preview</PackageVersion>
+		<AssemblyVersion>0.5.5</AssemblyVersion>
+		<PackageVersion>0.5.5-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>This is library injects data from one DTDL based graph, then converts and inserts the data into another DTDL base graph.</Description>
-		<AssemblyVersion>0.5.3</AssemblyVersion>
-		<PackageVersion>0.5.3-preview</PackageVersion>
+		<AssemblyVersion>0.5.4</AssemblyVersion>
+		<PackageVersion>0.5.4-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionProcessorBase.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionProcessorBase.cs
@@ -265,6 +265,10 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager
                     // Populate the content of the twin
                     var contentDictionary = new Dictionary<string, object>();
 
+                    // Add the alternate classification to the twin (brickSchema)
+                    var alternateClassification = new { BrickSchema = inputDtmi.AbsoluteUri };
+                    contentDictionary.Add("alternateClassification", JsonSerializer.SerializeToDocument(alternateClassification).RootElement);
+
                     // Get the model needed
                     if (TargetObjectModel.TryGetValue(outputDtmi, out var model))
                     {

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionProcessorBase.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionProcessorBase.cs
@@ -113,6 +113,16 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager
         /// <returns>An awaitable task.</returns>
         protected abstract Task ProcessSites(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// This method is called for each twin in the graph to add properties to the twin based on inputs.
+        /// </summary>
+        /// <param name="inputDtmi">The DTMI of the input twin.</param>
+        /// <returns>A dictionary of strings and objects to add to the contents of the twin.</returns>
+        protected virtual IDictionary<string, object> GetTargetSpecificContents(Dtmi inputDtmi)
+        {
+            return new Dictionary<string, object>();
+        }
+
         /// <inheritdoc/>
         public async Task IngestFromApiAsync(CancellationToken cancellationToken)
         {
@@ -265,9 +275,16 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager
                     // Populate the content of the twin
                     var contentDictionary = new Dictionary<string, object>();
 
-                    // Add the alternate classification to the twin (brickSchema)
-                    var alternateClassification = new { BrickSchema = inputDtmi.AbsoluteUri };
-                    contentDictionary.Add("alternateClassification", JsonSerializer.SerializeToDocument(alternateClassification).RootElement);
+                    // Check to see if there are any custom properties that need to be added to the twin based on the input DTMI.
+                    var targetSpecificContents = GetTargetSpecificContents(inputDtmi);
+
+                    if (targetSpecificContents != null)
+                    {
+                        foreach (var content in targetSpecificContents)
+                        {
+                            contentDictionary.Add(content.Key, JsonSerializer.SerializeToDocument(content.Value).RootElement);
+                        }
+                    }
 
                     // Get the model needed
                     if (TargetObjectModel.TryGetValue(outputDtmi, out var model))

--- a/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionProcessorBaseTests.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionProcessorBaseTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(2,twins.First().Value.Contents.Count);
+            Assert.Single(twins.First().Value.Contents);
             Assert.Equal("AV 31", twins.First().Value.Contents["name"].ToString());
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(2, twins.First().Value.Contents.Count);
+            Assert.Single(twins.First().Value.Contents);
             Assert.Equal("test", twins.First().Value.Contents["name"].ToString());
         }
 
@@ -322,7 +322,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(3, twins.First().Value.Contents.Count);
+            Assert.Equal(2, twins.First().Value.Contents.Count);
             Assert.Equal("test", twins.First().Value.Contents["name"].ToString());
             Assert.Equal("{ \"$metadata\": {} }", twins.First().Value.Contents["box"].ToString());
         }
@@ -351,7 +351,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(3, twins.First().Value.Contents.Count);
+            Assert.Equal(2, twins.First().Value.Contents.Count);
 
             var contents = twins.First().Value.Contents as IDictionary<string, object>;
             var externalIds = contents["externalIds"] as IDictionary<string, string>;
@@ -383,7 +383,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(3, twins.First().Value.Contents.Count);
+            Assert.Equal(2, twins.First().Value.Contents.Count);
 
             var contents = twins.First().Value.Contents as IDictionary<string, object>;
             var externalIds = contents["externalIds"] as IDictionary<string, string>;

--- a/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionProcessorBaseTests.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager/test/IngestionProcessorBaseTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Single(twins.First().Value.Contents);
+            Assert.Equal(2,twins.First().Value.Contents.Count);
             Assert.Equal("AV 31", twins.First().Value.Contents["name"].ToString());
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Single(twins.First().Value.Contents);
+            Assert.Equal(2, twins.First().Value.Contents.Count);
             Assert.Equal("test", twins.First().Value.Contents["name"].ToString());
         }
 
@@ -322,7 +322,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(2, twins.First().Value.Contents.Count);
+            Assert.Equal(3, twins.First().Value.Contents.Count);
             Assert.Equal("test", twins.First().Value.Contents["name"].ToString());
             Assert.Equal("{ \"$metadata\": {} }", twins.First().Value.Contents["box"].ToString());
         }
@@ -351,7 +351,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(2, twins.First().Value.Contents.Count);
+            Assert.Equal(3, twins.First().Value.Contents.Count);
 
             var contents = twins.First().Value.Contents as IDictionary<string, object>;
             var externalIds = contents["externalIds"] as IDictionary<string, string>;
@@ -383,7 +383,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Test
             Assert.Equal(basicDtId, twins.First().Key);
             Assert.Equal(basicDtId, twins.First().Value.Id);
             Assert.Equal(expectedDtmi, twins.First().Value.Metadata.ModelId);
-            Assert.Equal(2, twins.First().Value.Contents.Count);
+            Assert.Equal(3, twins.First().Value.Contents.Count);
 
             var contents = twins.First().Value.Contents as IDictionary<string, object>;
             var externalIds = contents["externalIds"] as IDictionary<string, string>;


### PR DESCRIPTION
### What
Adding alternateClassification as a standard content object to all twins

### Why
Sometimes the target twin needs values that come from the source twin but need to be calculated

### Tested
Validated that the correct values are coming out via the Unit Tests