### PR TITLE
Handle Empty Twins properly

### DIFF
--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from a Mapped DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.6.12</AssemblyVersion>
-		<PackageVersion>0.6.12-preview</PackageVersion>
+		<AssemblyVersion>0.6.13</AssemblyVersion>
+		<PackageVersion>0.6.13-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
@@ -160,7 +160,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped
         {
             if (!targetElement.TryGetProperty("id", out var basicDtIdProp))
             {
-                Logger.LogInformation("Building id is missing... skipping.");
+                Logger.LogWarning("Building id is missing... skipping.");
                 return;
             }
 

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
@@ -160,6 +160,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped
         {
             if (!targetElement.TryGetProperty("id", out var basicDtIdProp))
             {
+                Logger.LogInformation("Building id is missing... skipping.");
                 return;
             }
 

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/Metrics.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/Metrics.cs
@@ -16,6 +16,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped
         internal const string IdDimensionName = "Id";
         internal const string SiteDimensionName = "Site";
         internal const string BuildingDimensionName = "Building";
+        internal const string IsSuccessDimensionName = "IsSuccess";
 #pragma warning restore SA1600 // Elements should be documented
     }
 }

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/Data/site.json
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/Data/site.json
@@ -15,76 +15,79 @@
                     "Site"
                 ],
                 "buildings": [
-                    {
-                        "address": {
-                            "countryName": "United States",
-                            "dateCreated": "2023-04-25T05:59:46.467",
-                            "dateUpdated": "2023-04-25T05:59:46.467",
-                            "id": "METABCx712hSb9AGGvzJTtc3Ny",
-                            "locality": "Woodrow",
-                            "postalCode": "80757",
-                            "region": "Colorado",
-                            "streetAddress": "12188 Colorado Highway 71"
-                        },
+                  {
+                    "address": {
+                      "countryName": "United States",
+                      "dateCreated": "2023-04-25T05:59:46.467",
+                      "dateUpdated": "2023-04-25T05:59:46.467",
+                      "id": "METABCx712hSb9AGGvzJTtc3Ny",
+                      "locality": "Woodrow",
+                      "postalCode": "80757",
+                      "region": "Colorado",
+                      "streetAddress": "12188 Colorado Highway 71"
+                    },
+                    "description": null,
+                    "exactType": "Building",
+                    "id": "BLDG5o26DguWKu5T9nRvSYn5Em",
+                    "identities": [
+                      {},
+                      {}
+                    ],
+                    "name": "Intellicare Infirmary",
+                    "type": [
+                      "Building",
+                      "Class",
+                      "Entity",
+                      "Place"
+                    ],
+                    "floors": [
+                      {
+                        "dateCreated": "2023-04-05T06:30:55.906",
+                        "dateUpdated": "2023-04-13T04:28:13.132",
                         "description": null,
-                        "exactType": "Building",
-                        "id": "BLDG5o26DguWKu5T9nRvSYn5Em",
-                        "identities": [],
-                        "name": "Intellicare Infirmary",
+                        "exactType": "Floor",
+                        "id": "FLR297rRVtCm34Qzp2idcynFC",
+                        "level": 2,
+                        "name": "Floor_3",
                         "type": [
-                            "Building",
-                            "Class",
-                            "Entity",
-                            "Place"
-                        ],
-                        "floors": [
-                            {
-                                "dateCreated": "2023-04-05T06:30:55.906",
-                                "dateUpdated": "2023-04-13T04:28:13.132",
-                                "description": null,
-                                "exactType": "Floor",
-                                "id": "FLR297rRVtCm34Qzp2idcynFC",
-                                "level": 2,
-                                "name": "Floor_3",
-                                "type": [
-                                    "Class",
-                                    "Entity",
-                                    "Floor",
-                                    "Place"
-                                ]
-                            },
-                            {
-                                "dateCreated": "2023-04-05T06:30:55.901",
-                                "dateUpdated": "2023-04-12T23:50:41.896",
-                                "description": null,
-                                "exactType": "Floor",
-                                "id": "FLR8R1K5f9HtjRtVgohCAEGas",
-                                "level": 0,
-                                "name": "Floor_1",
-                                "type": [
-                                    "Class",
-                                    "Entity",
-                                    "Floor",
-                                    "Place"
-                                ]
-                            },
-                            {
-                                "dateCreated": "2023-04-05T06:30:55.904",
-                                "dateUpdated": "2023-04-12T23:50:41.879",
-                                "description": null,
-                                "exactType": "Floor",
-                                "id": "FLRUDY8ChSobVHrTvpfKk4fru",
-                                "level": 1,
-                                "name": "Floor_2",
-                                "type": [
-                                    "Class",
-                                    "Entity",
-                                    "Floor",
-                                    "Place"
-                                ]
-                            }
+                          "Class",
+                          "Entity",
+                          "Floor",
+                          "Place"
                         ]
-                    }
+                      },
+                      {
+                        "dateCreated": "2023-04-05T06:30:55.901",
+                        "dateUpdated": "2023-04-12T23:50:41.896",
+                        "description": null,
+                        "exactType": "Floor",
+                        "id": "FLR8R1K5f9HtjRtVgohCAEGas",
+                        "level": 0,
+                        "name": "Floor_1",
+                        "type": [
+                          "Class",
+                          "Entity",
+                          "Floor",
+                          "Place"
+                        ]
+                      },
+                      {
+                        "dateCreated": "2023-04-05T06:30:55.904",
+                        "dateUpdated": "2023-04-12T23:50:41.879",
+                        "description": null,
+                        "exactType": "Floor",
+                        "id": "FLRUDY8ChSobVHrTvpfKk4fru",
+                        "level": 1,
+                        "name": "Floor_2",
+                        "type": [
+                          "Class",
+                          "Entity",
+                          "Floor",
+                          "Place"
+                        ]
+                      }
+                    ]
+                  }
                 ]
             }
         ]


### PR DESCRIPTION
### What
Handle empty twins properly. This can happen if a twin is based on a dtdl interface and the type cast requested doesn't match the type of the object.

### Why
App was crashing in the situation where the twin id was empty because the casting done to the interface did not match the actual type of the instance of the twin

### Tested
Added test case to the site.json file. Verified previous code failed. Added new code. Green tests.