### PR TITLE
[SmartPlaces.Facilities.OntologyMapper] Migrate to DTDLParser [Part 1 of 4]

### DIFF
--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/IOntologyMappingManager.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/IOntologyMappingManager.cs
@@ -6,8 +6,8 @@
 
 namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
 {
-    using Microsoft.Azure.DigitalTwins.Parser;
-    using Microsoft.Azure.DigitalTwins.Parser.Models;
+    using DTDLParser;
+    using DTDLParser.Models;
 
     /// <summary>
     /// Defines the methods to be implemented by an OntologyMappingManager.

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -1,33 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Version>$(VersionPrefix)</Version>
-		<Authors>Microsoft</Authors>
-		<Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.7.5</AssemblyVersion>
-		<PackageVersion>0.7.5-preview</PackageVersion>
-		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
-		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-		<PackageReadmeFile>README.md</PackageReadmeFile>	
-	</PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\README.md" Pack="true" PackagePath="\" />
-	</ItemGroup>
-	
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Version>$(VersionPrefix)</Version>
+    <Authors>Microsoft</Authors>
+    <Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
+    <AssemblyVersion>0.8.0</AssemblyVersion>
+    <PackageVersion>0.8.0-preview</PackageVersion>
+    <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DTDLParser" Version="1.0.52" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMappingManager.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMappingManager.cs
@@ -7,8 +7,8 @@
 namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
 {
     using System.Text.RegularExpressions;
-    using Microsoft.Azure.DigitalTwins.Parser;
-    using Microsoft.Azure.DigitalTwins.Parser.Models;
+    using DTDLParser;
+    using DTDLParser.Models;
 
     /// <summary>
     /// Implements methods for consuming ontology mappings, i.e., to fetch ontology names (DTMIs, relationship names,

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
@@ -1,44 +1,43 @@
-<Project Sdk="Microsoft.NET.Sdk">
-	
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<ItemGroup>
-	  <None Remove="TestData\Space.json" />
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-	  <EmbeddedResource Include="TestData\Space.json" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="TestData\**\*" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="Moq" Version="4.18.2" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestData\**\*" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\src\OntologyMapper.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
-	<!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\OntologyMapper.csproj" />
+  </ItemGroup>
+
+  <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
+  <!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMappingManagerTests.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMappingManagerTests.cs
@@ -13,6 +13,13 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
 
     public class OntologyMappingManagerTests
     {
+        public static IEnumerable<object[]> DtdlFiles =>
+        new List<object[]>
+        {
+            new object[] { "DTDLv2.Space.json" },
+            new object[] { "DTDLv3.Space.json" },
+        };
+
         [Fact]
         public void TryGetInterfaceRemapDtmi_ReturnsTrue_When_Found()
         {
@@ -327,8 +334,7 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
         }
 
         [Theory]
-        [InlineData("DTDLv2.Space.json")]
-        [InlineData("DTDLv3.Space.json")]
+        [MemberData(nameof(DtdlFiles))]
         public void ValidateTargetOntologyMapping_ReturnsTrue_ForValidOntologyMapping(string model)
         {
             var targetObjectModel = GetTargetObjectModel(model);
@@ -345,26 +351,7 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
         }
 
         [Theory]
-        [InlineData("DTDLv2.Space.json")]
-        [InlineData("DTDLv3.Space.json")]
-        public void ValidateTargetOntologyMapping_ReturnsTrue_ExhaustiveMapping(string model)
-        {
-            var targetObjectModel = GetTargetObjectModel(model);
-
-            var mockOntologyLoader = new Mock<IOntologyMappingLoader>();
-            mockOntologyLoader.Setup(m => m.LoadOntologyMapping()).Returns(GetSpaceOnlyMapping);
-
-            var ontologyMappingManager = new OntologyMappingManager(mockOntologyLoader.Object);
-
-            var result = ontologyMappingManager.ValidateTargetOntologyMapping(targetObjectModel, out var invalidTargets);
-
-            Assert.True(result);
-            Assert.False(invalidTargets.Any());
-        }
-
-        [Theory]
-        [InlineData("DTDLv2.Space.json")]
-        [InlineData("DTDLv3.Space.json")]
+        [MemberData(nameof(DtdlFiles))]
         public void ValidateTargetOntologyMapping_ReturnsFalse_ForInvalidOntologyMapping(string model)
         {
             var targetObjectModel = GetTargetObjectModel(model);

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/TestData/DTDLv2/Space.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/TestData/DTDLv2/Space.json
@@ -1,0 +1,144 @@
+{
+  "@id": "dtmi:org:w3id:rec:Space;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Custom Properties"
+      },
+      "name": "customProperties",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "properties",
+          "schema": {
+            "@type": "Map",
+            "mapKey": {
+              "name": "propertyName",
+              "schema": "string"
+            },
+            "mapValue": {
+              "name": "propertyValue",
+              "schema": "string"
+            }
+          }
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Custom Tags"
+      },
+      "name": "customTags",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "tagName",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "tagValue",
+          "schema": "boolean"
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Identifiers"
+      },
+      "name": "identifiers",
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "namespace",
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "identifier",
+          "schema": "string"
+        }
+      },
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "name"
+      },
+      "name": "name",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "description": {
+        "en": "Polygon representing the spatial extent of this Space."
+      },
+      "displayName": {
+        "en": "geometry"
+      },
+      "maxMultiplicity": 1,
+      "name": "geometry",
+      "target": "dtmi:org:w3id:rec:Geometry;1",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "description": {
+        "en": "A georeference creates a relationship between the local coordinate system used within a building (e.g., measured in meters) and a geographic coordinate system (e.g., lat, long, alt), such that locally placed Spaces can be resolved and rendered in that geographic coordinate system (e.g., for mapping purposes)."
+      },
+      "displayName": {
+        "en": "georeference"
+      },
+      "maxMultiplicity": 1,
+      "name": "georeference",
+      "target": "dtmi:org:w3id:rec:Georeference;1",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "has part"
+      },
+      "name": "hasPart",
+      "target": "dtmi:org:w3id:rec:Space;1",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "is location of"
+      },
+      "name": "isLocationOf",
+      "writable": true
+    },
+    {
+      "@type": "Relationship",
+      "displayName": {
+        "en": "is part of"
+      },
+      "maxMultiplicity": 1,
+      "name": "isPartOf",
+      "target": "dtmi:org:w3id:rec:Space;1",
+      "writable": true
+    }
+  ],
+  "description": {
+    "en": "A contiguous part of the physical world that contains or can contain sub-spaces. E.g., a Region can contain many Sites, which in turn can contain many Buildings."
+  },
+  "displayName": {
+    "en": "Space"
+  },
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/TestData/DTDLv3/Space.json
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/TestData/DTDLv3/Space.json
@@ -96,7 +96,6 @@
     "en": "Space"
   },
   "@context": [
-    "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:initialization;1"
+    "dtmi:dtdl:context;3"
   ]
 }


### PR DESCRIPTION
### What
Move base OntologyMapper to use DTDLParser owned by the DigitalTwinConsortium

### Why
Microsoft handed over ownership of the DTDL Parsing to the [Digital Twin Consortium](https://www.digitaltwinconsortium.org/), this allows for DTDLv3 to be parsed by this library.

### Tested
Passed Unit Tests
Ran successfully on internal Pilot project