### PR TITLE
[SmartPlaces.Facilities.IngestionManager.Mapped] Migrate to DTDLParser [Part 3 of 4]

### DIFF
--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.14.0" />
     <PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
@@ -1,56 +1,56 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Version>$(VersionPrefix)</Version>
-		<Authors>Microsoft</Authors>
-		<Description>Support for converting from a Mapped DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.6.14</AssemblyVersion>
-		<PackageVersion>0.6.14-preview</PackageVersion>
-		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
-		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Version>$(VersionPrefix)</Version>
+    <Authors>Microsoft</Authors>
+    <Description>Support for converting from a Mapped DTDL-based Ontology to a different DTDL Based Ontology</Description>
+    <AssemblyVersion>0.7.0</AssemblyVersion>
+    <PackageVersion>0.7.0-preview</PackageVersion>
+    <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Azure.DigitalTwins.Core" Version="1.4.0" />
-		<PackageReference Include="Azure.Identity" Version="1.7.0" />
-		<PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.3" />
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.14.0" />
-		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.8.0" />
-		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-		<PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-		<PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.5.5-preview" />
-		<PackageReference Include="StackExchange.Redis" Version="2.6.70" />
-		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.DigitalTwins.Core" Version="1.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.7.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.0" />
+    <PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="6.4.0-preview" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.6.0-preview" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- Added Explicitly for CVE-2021-24112 -->
-	<!-- Can be removed once StackExchange.Redis fixes the vulnerability -->
-	<ItemGroup>
-		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
-	</ItemGroup>
+  <!-- Added Explicitly for CVE-2021-24112 -->
+  <!-- Can be removed once StackExchange.Redis fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\README.md" Pack="true" PackagePath="\" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>$(AssemblyName).Test</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>$(AssemblyName).Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.DigitalTwins.Core" Version="1.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.7.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.14.0" />
     <PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.8.0" />

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
@@ -9,9 +9,9 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped
     using System.Text.Json;
     using System.Threading.Tasks;
     using global::Azure.DigitalTwins.Core;
+    using DTDLParser;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Metrics;
-    using Microsoft.Azure.DigitalTwins.Parser;
     using Microsoft.Extensions.Logging;
     using Microsoft.SmartPlaces.Facilities.IngestionManager.Interfaces;
     using Microsoft.SmartPlaces.Facilities.OntologyMapper;

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/MappedGraphIngestionProcessor.cs
@@ -8,8 +8,8 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped
 {
     using System.Text.Json;
     using System.Threading.Tasks;
-    using global::Azure.DigitalTwins.Core;
     using DTDLParser;
+    using global::Azure.DigitalTwins.Core;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Metrics;
     using Microsoft.Extensions.Logging;

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/IngestionManager.Mapped.Test.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/IngestionManager.Mapped.Test.csproj
@@ -1,55 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
-	
-	<ItemGroup>
-	  <None Remove="Data\buildingThings.json" />
-	  <None Remove="Data\organization.json" />
-	  <None Remove="Data\site.json" />
-	  <None Remove="Data\thingPoints.json" />
-	</ItemGroup>
-	
-	<ItemGroup>
-	  <EmbeddedResource Include="Data\buildingThings.json" />
-	  <EmbeddedResource Include="Data\organization.json" />
-	  <EmbeddedResource Include="Data\thingPoints.json" />
-	  <EmbeddedResource Include="Data\site.json" />
-	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-		<PackageReference Include="Moq" Version="4.18.2" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\src\IngestionManager.Mapped.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Data\*.json" />
+  </ItemGroup>
 
-    <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
-	<!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-	</ItemGroup>
-	<ItemGroup>
-	  <None Update="Data\*.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
+    <PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\IngestionManager.Mapped.csproj" />
+  </ItemGroup>
+
+  <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
+  <!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
 
 </Project>

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/MappedDtdlTests.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/MappedDtdlTests.cs
@@ -10,28 +10,26 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped.Test
     using System.IO;
     using System.Linq;
     using System.Reflection;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.DigitalTwins.Parser;
-    using Microsoft.Azure.DigitalTwins.Parser.Models;
+    using DTDLParser;
     using Xunit;
-    using Xunit.Abstractions;
 
     public class MappedDtdlTests
     {
-        private readonly ITestOutputHelper output;
-
-        public MappedDtdlTests(ITestOutputHelper output)
+        [Theory]
+        [InlineData("mapped_dtdl.json")]
+        public void ValidateDtmisAreValid(string dtdl)
         {
-            this.output = output;
+            var parser = new ModelParser();
+            var inputDtmi = LoadDtdl(dtdl);
+            var inputModels = parser.Parse(inputDtmi);
+
+            Assert.NotEmpty(inputModels);
         }
 
-        // [Fact]
-        public async Task LoadDtdlMapped()
+        private static IEnumerable<string> LoadDtdl(string dtdlFile)
         {
-            ModelParser parser = new ModelParser();
-
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = assembly.GetManifestResourceNames().Single(str => str.EndsWith("mapped_dtdl.json"));
+            var resourceName = assembly.GetManifestResourceNames().Single(str => str.EndsWith(dtdlFile));
             List<string> dtdls = new List<string>();
 
             using (Stream? stream = assembly.GetManifestResourceStream(resourceName))
@@ -50,48 +48,7 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped.Test
                 }
             }
 
-            try
-            {
-                var objectModel = await parser.ParseAsync(dtdls);
-
-                var interfaces = objectModel.Values.Where(m => m.EntityKind == DTEntityKind.Interface);
-                var relationshipNames = new Dictionary<string, string>();
-
-                foreach (var intef in interfaces)
-                {
-                    var i = intef as DTInterfaceInfo;
-                    if (i != null)
-                    {
-                        var relationships = i.Contents.Where(c => c.Value.EntityKind == DTEntityKind.Relationship);
-                        foreach (var rel in relationships)
-                        {
-                            var r = rel.Value as DTRelationshipInfo;
-
-                            if (r != null)
-                            {
-                                var relName = r.Name;
-                                relationshipNames[relName] = r.Name;
-                            }
-                        }
-                    }
-                }
-
-                foreach (var relationship in relationshipNames.Values)
-                {
-                    output.WriteLine(relationship);
-                }
-            }
-            catch (ParsingException ex)
-            {
-                output.WriteLine(ex.ToString());
-
-                foreach (var err in ex.Errors)
-                {
-                    output.WriteLine(err.ToString());
-                }
-
-                throw;
-            }
+            return dtdls;
         }
     }
 }

--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/MappedGraphIngestionProcessorTests.cs
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/test/MappedGraphIngestionProcessorTests.cs
@@ -23,13 +23,9 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped.Test
     using Microsoft.SmartPlaces.Facilities.OntologyMapper;
     using Moq;
     using Xunit;
-    using Xunit.Abstractions;
 
     public class MappedGraphIngestionProcessorTests
     {
-#pragma warning disable IDE0052 // Remove unread private members
-        private readonly ITestOutputHelper output;
-#pragma warning restore IDE0052 // Remove unread private members
 
         private const string organizationQuery = "{sites{description,exactType,id,name}}";
         private const string siteQuery = "{ sites(filter: { id: { eq: \"SITE44nUdjjbqSX1sEXuwEWucr\"} }) { description,exactType,id,name,dateCreated,dateUpdated,type,buildings{ address{countryName,dateCreated,dateUpdated,id,locality,postalCode,region,streetAddress},description,exactType,id,identities { ... on ExternalIdentity { dateCreated, dateUpdated, value } },name,type,floors{ dateCreated,dateUpdated,description,exactType,id,level,name,type} } } }";
@@ -41,10 +37,8 @@ namespace Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped.Test
         private readonly JsonDocument? buildingThingsJsonDocument;
         private readonly JsonDocument? thingPointsJsonDocument;
 
-        public MappedGraphIngestionProcessorTests(ITestOutputHelper output)
+        public MappedGraphIngestionProcessorTests()
         {
-            this.output = output;
-
             organizationJsonDocument = GetDocumentFromResource("organization.json");
             siteJsonDocument = GetDocumentFromResource("site.json");
             buildingThingsJsonDocument = GetDocumentFromResource("buildingThings.json");


### PR DESCRIPTION
### What
Move IngestionManager.Mapped to use latest IngestionManager
Implemented validation test for Mapped's DTDL file

### Why
Microsoft handed over ownership of the DTDL Parsing to the [Digital Twin Consortium](https://www.digitaltwinconsortium.org/), this allows for DTDLv3 to be parsed by this library.

### Tested
Passed Unit Tests
Ran successfully on internal Pilot project