### PR TITLE
[SmartPlaces.Facilities.Samples] Migrate to DTDLParser [Part 4 of 4]

### DIFF
--- a/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Processors/TelemetryIngestionProcessor.cs
+++ b/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Processors/TelemetryIngestionProcessor.cs
@@ -16,11 +16,11 @@ namespace Telemetry.Processors
     using Azure.Identity;
     using Azure.Messaging.EventHubs;
     using Google.Protobuf;
+    using DTDLParser;
     using Mapped.Cloud.Types;
     using Mapped.Gateway;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Metrics;
-    using Microsoft.Azure.DigitalTwins.Parser;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
     using Microsoft.SmartPlaces.Facilities.IngestionManager;

--- a/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Telemetry.csproj
+++ b/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Telemetry.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.3.12-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.6.0-preview" />
     <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
 

--- a/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
+++ b/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
@@ -1,54 +1,54 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<AssemblyName>$(MSBuildProjectName)</AssemblyName>
-		<RootNamespace>$(MSBuildProjectName)</RootNamespace>
-		<CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\..\.config\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-		<Deterministic>true</Deterministic>
-		<LangVersion>10</LangVersion>
-		<RepositoryRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..'))</RepositoryRootPath>
-		<DebugType>Full</DebugType>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\..\.config\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
+    <Deterministic>true</Deterministic>
+    <LangVersion>10</LangVersion>
+    <RepositoryRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..'))</RepositoryRootPath>
+    <DebugType>Full</DebugType>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
-		<PackageReference Include="Azure.Identity" Version="1.7.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
-		<PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped" Version="0.5.0-preview" />
-		<PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper.Mapped" Version="0.10.1-preview" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Include="Azure.Identity" Version="1.7.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped" Version="0.7.0-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper.Mapped" Version="0.11.0-preview" />
+  </ItemGroup>
 
-	<PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
-		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-		<MSBuildTreatWarningsAsErrors>True</MSBuildTreatWarningsAsErrors>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>True</MSBuildTreatWarningsAsErrors>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\..\..\.config\rulesets\stylecop.json">
-			<Visible>false</Visible>
-		</AdditionalFiles>
-	</ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\..\..\.config\rulesets\stylecop.json">
+      <Visible>false</Visible>
+    </AdditionalFiles>
+  </ItemGroup>
 
-    <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
-	<!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-	</ItemGroup>
+  <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
+  <!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### What
Move IngestionManager.Mapped to use latest IngestionManager
Implemented validation test for Mapped's DTDL file

### Why
Microsoft handed over ownership of the DTDL Parsing to the [Digital Twin Consortium](https://www.digitaltwinconsortium.org/), this allows for DTDLv3 to be parsed by this library.

### Tested
Ran successfully on internal Pilot project