### PR TITLE
[SmartPlaces.Facilities.OntologyMapper] Add NetStandard2.0, Net7.0, and Net8.0 Support [Part 1 of 4]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
       - "Tyler-Angell"
       - "hammar"
   - package-ecosystem: "nuget"
+    directory: "/SmartPlaces.Facilities/lib/IngestionManager/test"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: Microsoft.SmartPlaces.Facilities.*
+    reviewers:
+      - "Tyler-Angell"
+      - "hammar"
+  - package-ecosystem: "nuget"
     directory: "/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src"
     schedule:
       interval: "daily"
@@ -30,7 +39,7 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      - dependency-name: Mapped.*
+      - dependency-name: Microsoft.SmartPlaces.Facilities.*
     reviewers:
       - "Tyler-Angell"
       - "hammar"
@@ -40,7 +49,15 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
-      - dependency-name: DTDLParser
+    reviewers:
+      - "Tyler-Angell"
+      - "hammar"
+  - package-ecosystem: "nuget"
+    directory: "/SmartPlaces.Facilities/lib/OntologyMapper/test"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: Microsoft.SmartPlaces.Facilities.*
     reviewers:
       - "Tyler-Angell"
       - "hammar"
@@ -60,8 +77,6 @@ updates:
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
       - dependency-name: Mapped.*
-      - dependency-name: RealEstateCore.*
-      - dependency-name: WillowInc.*
     reviewers:
       - "Tyler-Angell"
       - "hammar"
@@ -70,6 +85,7 @@ updates:
     schedule:
       interval: "daily"
     allow:
+      - dependency-name: Microsoft.SmartPlaces.Facilities.*
       - dependency-name: Mapped.*
     reviewers:
       - "Tyler-Angell"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,15 +16,6 @@ updates:
       - "Tyler-Angell"
       - "hammar"
   - package-ecosystem: "nuget"
-    directory: "/SmartPlaces.Facilities/lib/IngestionManager/test"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: Microsoft.SmartPlaces.Facilities.*
-    reviewers:
-      - "Tyler-Angell"
-      - "hammar"
-  - package-ecosystem: "nuget"
     directory: "/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src"
     schedule:
       interval: "daily"
@@ -39,7 +30,7 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      - dependency-name: Microsoft.SmartPlaces.Facilities.*
+      - dependency-name: Mapped.*
     reviewers:
       - "Tyler-Angell"
       - "hammar"
@@ -49,15 +40,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
-    reviewers:
-      - "Tyler-Angell"
-      - "hammar"
-  - package-ecosystem: "nuget"
-    directory: "/SmartPlaces.Facilities/lib/OntologyMapper/test"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: Microsoft.SmartPlaces.Facilities.*
+      - dependency-name: DTDLParser
     reviewers:
       - "Tyler-Angell"
       - "hammar"
@@ -77,6 +60,8 @@ updates:
     allow:
       - dependency-name: Microsoft.SmartPlaces.Facilities.*
       - dependency-name: Mapped.*
+      - dependency-name: RealEstateCore.*
+      - dependency-name: WillowInc.*
     reviewers:
       - "Tyler-Angell"
       - "hammar"
@@ -85,7 +70,6 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      - dependency-name: Microsoft.SmartPlaces.Facilities.*
       - dependency-name: Mapped.*
     reviewers:
       - "Tyler-Angell"

--- a/.github/workflows/SmartPlaces_Facilities.yml
+++ b/.github/workflows/SmartPlaces_Facilities.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Restore dependencies
       shell: pwsh

--- a/.github/workflows/SmartPlaces_Facilities_Main.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Main.yml
@@ -11,7 +11,7 @@ on:
     ]
 
 env: 
-  DOTNET_VERSION: '6.x' 
+  DOTNET_VERSION: '8.x' 
 
 jobs:
   build:

--- a/.github/workflows/SmartPlaces_Facilities_PR.yml
+++ b/.github/workflows/SmartPlaces_Facilities_PR.yml
@@ -11,7 +11,7 @@ on:
     ]
 
 env: 
-  DOTNET_VERSION: '6.x' 
+  DOTNET_VERSION: '8.x' 
 
 jobs:
   build:

--- a/SmartPlaces.Facilities/.config/common.props
+++ b/SmartPlaces.Facilities/.config/common.props
@@ -10,6 +10,10 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NetCoreAppCurrent>net8.0</NetCoreAppCurrent>
+    <NetCoreAppPrevious>net7.0</NetCoreAppPrevious>
+    <NetCoreAppMinimum>net6.0</NetCoreAppMinimum>
+    <NetFrameworkMinimum>net462</NetFrameworkMinimum>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">

--- a/SmartPlaces.Facilities/global.json
+++ b/SmartPlaces.Facilities/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.202",
+    "version": "8.0.0",
     "rollForward": "feature"
   }
 }

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/FileOntologyMappingLoader.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/FileOntologyMappingLoader.cs
@@ -17,6 +17,10 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
     {
         private readonly ILogger logger;
         private readonly string filePath = string.Empty;
+        private readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
+        {
+            ReadCommentHandling = JsonCommentHandling.Skip,
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileOntologyMappingLoader"/> class.
@@ -44,15 +48,10 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
 
             var file = File.ReadAllText(filePath);
 
-            var options = new JsonSerializerOptions
-            {
-                ReadCommentHandling = JsonCommentHandling.Skip,
-            };
-
             OntologyMapping? mappings;
             try
             {
-                mappings = JsonSerializer.Deserialize<OntologyMapping>(file, options);
+                mappings = JsonSerializer.Deserialize<OntologyMapping>(file, jsonSerializerOptions);
             }
             catch (JsonException jex)
             {

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Version>$(VersionPrefix)</Version>
     <Authors>Microsoft</Authors>
     <Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-    <AssemblyVersion>0.8.0</AssemblyVersion>
-    <PackageVersion>0.8.0-preview</PackageVersion>
+    <AssemblyVersion>0.9.0</AssemblyVersion>
+    <PackageVersion>0.9.0-preview</PackageVersion>
     <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="DTDLParser" Version="1.0.52" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Version>$(VersionPrefix)</Version>
     <Authors>Microsoft</Authors>
     <Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-    <AssemblyVersion>0.9.0</AssemblyVersion>
-    <PackageVersion>0.9.0-preview</PackageVersion>
+    <AssemblyVersion>0.8.1</AssemblyVersion>
+    <PackageVersion>0.8.1-preview</PackageVersion>
     <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMapper.Test.csproj
@@ -1,31 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="TestData\**\*" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="TestData\**\*" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -35,9 +31,4 @@
     <ProjectReference Include="..\src\OntologyMapper.csproj" />
   </ItemGroup>
 
-  <!-- Added Explicitly for GHSA-5crp-9r3c-p9vr -->
-  <!-- Can be removed once Microsoft.NET.Test.Sdk fixes the vulnerability -->
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-  </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMappingManagerTests.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/test/OntologyMappingManagerTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
 {
     using System.Reflection;
+    using System.Reflection.PortableExecutable;
     using DTDLParser;
     using DTDLParser.Models;
     using Microsoft.SmartPlaces.Facilities.OntologyMapper;
@@ -13,11 +14,9 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
 
     public class OntologyMappingManagerTests
     {
-        public static IEnumerable<object[]> DtdlFiles =>
-        new List<object[]>
-        {
-            new object[] { "DTDLv2.Space.json" },
-            new object[] { "DTDLv3.Space.json" },
+        public static TheoryData<string> DtdlFiles => new() {
+            "DTDLv2.Space.json",
+            "DTDLv3.Space.json",
         };
 
         [Fact]
@@ -347,7 +346,7 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper.Test
             var result = ontologyMappingManager.ValidateTargetOntologyMapping(targetObjectModel, out var invalidTargets);
 
             Assert.True(result);
-            Assert.False(invalidTargets.Any());
+            Assert.Empty(invalidTargets);
         }
 
         [Theory]

--- a/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/ProcessTelemetry.cs
+++ b/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/ProcessTelemetry.cs
@@ -103,7 +103,7 @@ namespace Telemetry
         public override async Task StopAsync(CancellationToken cancellationToken)
         {
             // Stop the processing
-            logger.LogInformation("Shutting down Telemetry Service", nameof(ITelemetryIngestionProcessor));
+            logger.LogInformation("Shutting down Telemetry Service");
             if (processor != null)
             {
                 await processor.StopProcessingAsync(cancellationToken);


### PR DESCRIPTION
### What
Add support for NetStandard2.0, Net7.0, Net8.0 and NetFramework 4.6.2

### Why
Following in the footsteps of [Dotnet](https://github.com/dotnet/runtime/blob/aeceba3f3b84e21d7dab99c45f2163756f7ba3c3/src/libraries/Microsoft.Extensions.Configuration.Binder/src/Microsoft.Extensions.Configuration.Binder.csproj#L4C5-L4C143) I've added multitargeting for the Core Current, Previous, and Minimum, netstandard2.0, and Framework minimum as a target, 

This expands the flexibility of this nuget so that consumers can target whichever .NET version they are comfortable with.

### Tested
Passed Unit Tests
Ran successfully on internal Pilot project