### PR TITLE
[CG] Fix Vulnerable Packages

### DIFF
--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
@@ -8,8 +8,8 @@
     <Version>$(VersionPrefix)</Version>
     <Authors>Microsoft</Authors>
     <Description>Support for converting from a Mapped DTDL-based Ontology to a different DTDL Based Ontology</Description>
-    <AssemblyVersion>0.7.1</AssemblyVersion>
-    <PackageVersion>0.7.1-preview</PackageVersion>
+    <AssemblyVersion>0.7.2</AssemblyVersion>
+    <PackageVersion>0.7.2-preview</PackageVersion>
     <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -30,12 +30,18 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.6.1-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.6.2-preview" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.12" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Can be removed once Microsoft.Extensions.Hosting & Azure.Storage.Blobs & Azure.Messaging.EventHubs & Azure.Identity & Azure.DigitalTwins.Core & Microsoft.SmartPlaces.Facilities.IngestionManager fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
@@ -8,8 +8,8 @@
     <Version>$(VersionPrefix)</Version>
     <Authors>Microsoft</Authors>
     <Description>This is library injects data from one DTDL based graph, then converts and inserts the data into another DTDL base graph.</Description>
-    <AssemblyVersion>0.6.2</AssemblyVersion>
-    <PackageVersion>0.6.2-preview</PackageVersion>
+    <AssemblyVersion>0.6.3</AssemblyVersion>
+    <PackageVersion>0.6.3-preview</PackageVersion>
     <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper" Version="0.8.0-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper" Version="0.8.2-preview" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
     <PackageReference Include="Polly" Version="8.4.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.12" />
@@ -37,6 +37,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Can be removed once Microsoft.Extensions.Hosting & DTDLParser & Azure.Identity & Azure.DigitalTwins.Core & Microsoft.SmartPlaces.Facilities.OntologyMapper fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+  </ItemGroup>
+
+  <!-- Added Explicitly for Bug -->
+  <!-- Can be removed once Azure.DigitalTwins.Core & Azure.Identity fixes the bug -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.42.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
@@ -8,8 +8,8 @@
     <Version>$(VersionPrefix)</Version>
     <Authors>Microsoft</Authors>
     <Description>Support for converting from one Mapped Ontology to a different DTDL Based Ontology</Description>
-    <AssemblyVersion>0.11.1</AssemblyVersion>
-    <PackageVersion>0.11.1-preview</PackageVersion>
+    <AssemblyVersion>0.11.2</AssemblyVersion>
+    <PackageVersion>0.11.2-preview</PackageVersion>
     <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -28,10 +28,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper" Version="0.8.1-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper" Version="0.8.2-preview" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Can be removed once Microsoft.SmartPlaces.Facilities.OntologyMapper fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -8,8 +8,8 @@
     <Version>$(VersionPrefix)</Version>
     <Authors>Microsoft</Authors>
     <Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-    <AssemblyVersion>0.8.2</AssemblyVersion>
-    <PackageVersion>0.8.2-preview</PackageVersion>
+    <AssemblyVersion>0.8.3</AssemblyVersion>
+    <PackageVersion>0.8.3-preview</PackageVersion>
     <RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -29,5 +29,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Can be removed once DTDLParser fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/samples/EdgeGateway.Mapped/src/EdgeGateway.csproj
+++ b/SmartPlaces.Facilities/samples/EdgeGateway.Mapped/src/EdgeGateway.csproj
@@ -28,4 +28,10 @@
     <PackageReference Include="Polly" Version="8.4.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.12" />
   </ItemGroup>
+
+  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Can be removed once Microsoft.Extensions.Logging.Console & Microsoft.Extensions.Hosting & Microsoft.Azure.Devices.Client & Azure.Identity & Azure.Extensions.AspNetCore.Configurtation.Secrets & Microsoft.SmartPlaces.Facilities.IngestionManager fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+  </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Telemetry.csproj
+++ b/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Telemetry.csproj
@@ -26,8 +26,14 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.6.1-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager" Version="0.6.2-preview" />
     <PackageReference Include="Polly" Version="8.4.1" />
+  </ItemGroup>
+
+  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Can be removed once Microsoft.Extensions.Logging.Console & Microsoft.Extensions.Hosting & Azure.Messaging.EventHubs.Processor & Azure.Messaging.EventHubs & Azure.Identity & Azure.Extensions.AspNetCore.Configurtation.Secrets & Microsoft.SmartPlaces.Facilities.IngestionManager fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
+++ b/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped" Version="0.7.0-preview" />
-    <PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper.Mapped" Version="0.11.0-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped" Version="0.7.1-preview" />
+    <PackageReference Include="Microsoft.SmartPlaces.Facilities.OntologyMapper.Mapped" Version="0.11.1-preview" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
@@ -53,5 +53,11 @@
   <!-- Can be removed once Microsoft.AspNet.WebApi.Client fixes the vulnerability -->
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Can be removed once Microsoft.Extensions.Logging.Console & Microsoft.Extensions.Hosting & Azure.Identity & Azure.Extensions.AspNetCore.Configurtation.Secrets & Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped & Microsoft.SmartPlaces.Facilities.OntologyMapper.Mapped fixes the vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### What
Pin vulnerable dependent packages to patched versions.

### Why
Vulnerabilities discovered in dependent packages. Pinning allows override of dependent code.

### Tested
Ran unit tests