### PR TITLE
[CG] Fix Vulnerable Packages

### DIFF
--- a/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager.Mapped/src/IngestionManager.Mapped.csproj
@@ -38,10 +38,10 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Added Explicitly for CVE-2024-30105 & CVE-2024-43485 -->
   <!-- Can be removed once Microsoft.Extensions.Hosting & Azure.Storage.Blobs & Azure.Messaging.EventHubs & Azure.Identity & Azure.DigitalTwins.Core & Microsoft.SmartPlaces.Facilities.IngestionManager fixes the vulnerability -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
+++ b/SmartPlaces.Facilities/lib/IngestionManager/src/IngestionManager.csproj
@@ -39,10 +39,10 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Added Explicitly for CVE-2024-30105 & CVE-2024-43485 -->
   <!-- Can be removed once Microsoft.Extensions.Hosting & DTDLParser & Azure.Identity & Azure.DigitalTwins.Core & Microsoft.SmartPlaces.Facilities.OntologyMapper fixes the vulnerability -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <!-- Added Explicitly for Bug -->

--- a/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper.Mapped/src/OntologyMapper.Mapped.csproj
@@ -35,9 +35,9 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Added Explicitly for CVE-2024-30105 & CVE-2024-43485 -->
   <!-- Can be removed once Microsoft.SmartPlaces.Facilities.OntologyMapper fixes the vulnerability -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -31,9 +31,9 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Added Explicitly for CVE-2024-30105 & CVE-2024-43485 -->
   <!-- Can be removed once DTDLParser fixes the vulnerability -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/samples/EdgeGateway.Mapped/src/EdgeGateway.csproj
+++ b/SmartPlaces.Facilities/samples/EdgeGateway.Mapped/src/EdgeGateway.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="StackExchange.Redis" Version="2.8.12" />
   </ItemGroup>
 
-  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Added Explicitly for CVE-2024-30105 & CVE-2024-43485 -->
   <!-- Can be removed once Microsoft.Extensions.Logging.Console & Microsoft.Extensions.Hosting & Microsoft.Azure.Devices.Client & Azure.Identity & Azure.Extensions.AspNetCore.Configurtation.Secrets & Microsoft.SmartPlaces.Facilities.IngestionManager fixes the vulnerability -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Telemetry.csproj
+++ b/SmartPlaces.Facilities/samples/Telemetry.Mapped/src/Telemetry.csproj
@@ -30,10 +30,10 @@
     <PackageReference Include="Polly" Version="8.4.1" />
   </ItemGroup>
 
-  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Added Explicitly for CVE-2024-30105 & CVE-2024-43485 -->
   <!-- Can be removed once Microsoft.Extensions.Logging.Console & Microsoft.Extensions.Hosting & Azure.Messaging.EventHubs.Processor & Azure.Messaging.EventHubs & Azure.Identity & Azure.Extensions.AspNetCore.Configurtation.Secrets & Microsoft.SmartPlaces.Facilities.IngestionManager fixes the vulnerability -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
+++ b/SmartPlaces.Facilities/samples/Topology/src/Topology.csproj
@@ -55,9 +55,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <!-- Added Explicitly for CVE-2024-30105 -->
+  <!-- Added Explicitly for CVE-2024-30105 & CVE-2024-43485 -->
   <!-- Can be removed once Microsoft.Extensions.Logging.Console & Microsoft.Extensions.Hosting & Azure.Identity & Azure.Extensions.AspNetCore.Configurtation.Secrets & Microsoft.SmartPlaces.Facilities.IngestionManager.Mapped & Microsoft.SmartPlaces.Facilities.OntologyMapper.Mapped fixes the vulnerability -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### What
Pin vulnerable dependent packages to patched versions.

### Why
Vulnerabilities discovered in dependent packages. Pinning allows override of dependent code.

### Tested
Ran unit tests